### PR TITLE
change style for errors and display

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -41,8 +41,8 @@ class ScriptView extends ScrollView
 
     console.log("Running " + command + " " + args.join(" "))
 
-    stdout = (output) => @addLine(output)
-    stderr = (output) => @addLine(output, "error")
+    stdout = (output) => @addLine(output, "stdout")
+    stderr = (output) => @addLine(output, "stderr")
     exit = (return_code) -> console.log("Exited with #{return_code}")
 
     bufferedProcess = new BufferedProcess({command, args, options, stdout, stderr, exit})

--- a/stylesheets/script.less
+++ b/stylesheets/script.less
@@ -13,6 +13,10 @@
   background-color: #444;
 }
 
+.stderr {
+  color: red;
+}
+
 .line {
   border-radius: 0px;
 }


### PR DESCRIPTION
changed style of errors. atom has a built in error class that flashes red when applied to an element. added that for errors and stderr output. also removed border-radius from lines which caused seperate lines to have rounded corners.
