### PR TITLE
Use spacepen's outlet to append to the output div

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -7,7 +7,7 @@ class ScriptView extends ScrollView
 
   @content: ->
     @div class: 'script', tabindex: -1, =>
-      @div class: 'output'
+      @div class: 'output', outlet: 'output'
 
   constructor: (interpreter, make_args) ->
     super
@@ -22,7 +22,7 @@ class ScriptView extends ScrollView
 
   addLine: (line, out_type) ->
     #console.log(line)
-    @find("div.output").append("<pre class='line #{out_type}'>#{line}</pre>")
+    @output.append("<pre class='line #{out_type}'>#{line}</pre>")
 
   runit: (err, code) ->
 


### PR DESCRIPTION
[SpacePen](http://atom.github.io/space-pen/) is the client side view framework that Atom relies heavily on. For this I've switched us to using [outlets](https://github.com/atom/space-pen#outlets-and-events).
