### PR TITLE
added separate icon for kill

### DIFF
--- a/lib/header-view.coffee
+++ b/lib/header-view.coffee
@@ -13,8 +13,9 @@ class HeaderView extends View
     atom.workspaceView.trigger "script:close-view"
 
   setStatus: (status) ->
-    @status.removeClass('icon-hourglass icon-stop icon-check')
+    @status.removeClass('icon-alert icon-check icon-hourglass icon-stop')
     switch status
       when "start" then @status.addClass('icon-hourglass')
-      when "err" then @status.addClass('icon-alert')
       when "stop" then @status.addClass('icon-check')
+      when "kill" then @status.addClass('icon-stop')
+      when "err" then @status.addClass('icon-alert')

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -155,7 +155,7 @@ class ScriptView extends View
     # Kill existing process if available
     if @bufferedProcess? and @bufferedProcess.process?
       @display("stdout", "^C")
-      @headerView.setStatus("err")
+      @headerView.setStatus("kill")
       @bufferedProcess.kill()
 
   display: (css, line) ->

--- a/stylesheets/script.less
+++ b/stylesheets/script.less
@@ -21,6 +21,10 @@
     padding-left: 9px;
   }
 
+  .icon-alert {
+    color: @text-color-warning;
+  }
+
   .icon-check {
     color: @text-color-success;
   }
@@ -29,8 +33,8 @@
     color: @text-color;
   }
 
-  .icon-alert {
-    color: @text-color-warning;
+  .icon-stop {
+    color: @text-color-error;  
   }
 }
 


### PR DESCRIPTION
i've added in the stop icon with ui-variable red color for when the program is halted simply because this is really different than an actual error. we have 4 distinct things happening. loading or running, exit 0 completion, exit code or error, and ctrl-c kill or stop process. because of this i feel we need all separate icons to indicate feedback for each one. i've attached screenshots of them in action.

![screen shot 2014-03-06 at 3 51 00 pm](https://f.cloud.github.com/assets/1441464/2351246/f89f1512-a579-11e3-8bd9-701fbf911af6.png)
![screen shot 2014-03-06 at 3 51 15 pm](https://f.cloud.github.com/assets/1441464/2351250/fc2387e0-a579-11e3-9e84-3d515a6de4e5.png)
![screen shot 2014-03-06 at 3 51 22 pm](https://f.cloud.github.com/assets/1441464/2351258/05b68de8-a57a-11e3-8d9d-aa77e681223e.png)
![screen shot 2014-03-06 at 3 51 46 pm](https://f.cloud.github.com/assets/1441464/2351263/144c5c3e-a57a-11e3-88f1-e432f38303ed.png)
