### PR TITLE
Hack the check box

### DIFF
--- a/lib/header-view.coffee
+++ b/lib/header-view.coffee
@@ -5,9 +5,9 @@ class HeaderView extends View
 
   @content: ->
     @div class: 'panel-heading padded heading headerView', =>
-      @span class: 'heading-close icon-remove-close', outlet: 'closeButton', click: 'close'
       @span class: 'heading-title', outlet: 'title'
       @span class: 'heading-status', outlet: 'status'
+      @span class: 'heading-close icon-remove-close pull-right', outlet: 'closeButton', click: 'close'
 
   close: ->
     atom.workspaceView.trigger "script:close-view"

--- a/stylesheets/script.less
+++ b/stylesheets/script.less
@@ -11,6 +11,7 @@
 
   .heading-close {
     color: @text-color-highlight;
+    padding-right: 200px; /* Complete fixed hack */
   }
 
   .heading-title {
@@ -34,7 +35,7 @@
   }
 
   .icon-stop {
-    color: @text-color-error;  
+    color: @text-color-error;
   }
 }
 


### PR DESCRIPTION
Fixes #50.

The close check box now appears on the far right.

The real issue here is the computed width of the headerView. It comes out to be 200px more than the scriptView or the status bar. Is the 100% width here including the tree view? I'm no CSS wiz, there's got to be a better way.
