### PR TITLE
Move header outside of scroll pane

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -8,10 +8,11 @@ class ScriptView extends View
   @bufferedProcess: null
 
   @content: ->
-    # Display layout and outlets
-    @div class: 'tool-panel panel panel-bottom padding scriptView', outlet: 'script', tabindex: -1, =>
+    @div class: 'outer-scriptView', =>
       @subview 'headerView', new HeaderView()
-      @div class: 'panel-body padded output', outlet: 'output'
+      # Display layout and outlets
+      @div class: 'tool-panel panel panel-bottom padding scriptView', outlet: 'script', tabindex: -1, =>
+        @div class: 'panel-body padded output', outlet: 'output'
 
   initialize: (serializeState) ->
     # Bind commands

--- a/stylesheets/script.less
+++ b/stylesheets/script.less
@@ -8,10 +8,12 @@
 .headerView {
   position: fixed;
   width: 100%;
+  z-index:10;
+  position:relative;
+
 
   .heading-close {
     color: @text-color-highlight;
-    padding-right: 200px; /* Complete fixed hack */
   }
 
   .heading-title {
@@ -49,7 +51,6 @@
   }
 
   .output {
-    margin-top: 35px;
   }
 
   .stderr {


### PR DESCRIPTION
Went ahead and moved the header outside of the output box.

Demo:

![666defeated](https://f.cloud.github.com/assets/836375/2358984/79ac738c-a612-11e3-9f82-2f68fbda2034.gif)

Fixes #56.
