### PR TITLE
Apply class native-key-bindings

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -13,7 +13,7 @@ class ScriptView extends View
     @div class: 'outer-scriptView', =>
       @subview 'headerView', new HeaderView()
       # Display layout and outlets
-      @div class: 'tool-panel panel panel-bottom padding scriptView', outlet: 'script', tabindex: -1, =>
+      @div class: 'tool-panel panel panel-bottom padding scriptView native-key-bindings', outlet: 'script', tabindex: -1, =>
         @div class: 'panel-body padded output', outlet: 'output'
 
   initialize: (serializeState) ->


### PR DESCRIPTION
As @EntilZha figured out, adding class `native-key-bindings` to the view allows for use of keys within the pane. This fixes #78, allowing people to copy output from the terminal output.

![copypasta](https://f.cloud.github.com/assets/836375/2507720/61cfabee-b3c3-11e3-9698-c948ba158732.gif)
