### PR TITLE
Use underscore to escape HTML entities from stdout

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -1,6 +1,7 @@
 grammarMap = require './grammars'
 {View, BufferedProcess} = require 'atom'
 HeaderView = require './header-view'
+_ = require 'underscore'
 
 AnsiFilter = require 'ansi-to-html'
 
@@ -166,6 +167,8 @@ class ScriptView extends View
       @bufferedProcess.kill()
 
   display: (css, line) ->
+
+    line = _.escape(line)
     line = @ansiFilter.toHtml(line)
-    # For display
+
     @output.append("<pre class='line #{css}'>#{line}</pre>")

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "ansi-to-html": ">0.1.0"
+    "ansi-to-html": ">0.1.0",
+    "underscore": "~1.5.2"
   }
 }


### PR DESCRIPTION
This fixes #80, namely to make sure that HTML entities are properly escaped.

I chose to use underscore because we don't necessarily need all of underscore-plus. I'm amenable to changing this though, as we may in the future want their modifier key map and other utilities.

@hansrodtang, @ciarand - we can continue discussion here. I've checked out ANSI colored output + html entities and all is good.
