### PR TITLE
Added Literate CoffeeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently supports:
 
   * Bash
   * Coffeescript
+  * CoffeeScript (Literate) <sup>^</sup>
   * Erlang <sup>†</sup>
   * Elixir
   * Go <sup>*</sup>
@@ -32,6 +33,8 @@ You only have to add a few lines in a PR to support another.
 <sup>\*</sup> Go and F# only support file based runs
 
 <sup>†</sup> Erlang uses `erl` for limited selection based runs (see [#70](https://github.com/rgbkrk/atom-script/pull/70))
+
+<sup>^</sup> Running selections of code for CoffeeScript (Literate) only works when selecting just the code blocks
 
 ## Installation
 

--- a/examples/this-is-code.coffee.md
+++ b/examples/this-is-code.coffee.md
@@ -1,0 +1,3 @@
+These are just words.
+
+      console.log 'This is code!'

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -85,3 +85,8 @@ module.exports =
     command: "lua"
     "Selection Based": (code) -> ['-e', code]
     "File Based": (filename) -> [filename]
+
+  "CoffeeScript (Literate)":
+    command: "coffee"
+    "Selection Based": (code) -> ['-e', code]
+    "File Based": (filename) -> [filename]


### PR DESCRIPTION
Added support for Literate CoffeeScript. The commands are identical to regular CoffeeScript. The only kicker is that running selections of code only works if you select the actual CoffeeScript code.
