### PR TITLE
save file before run if already exists

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -111,6 +111,7 @@ class ScriptView extends View
     if (not selectedText? or not selectedText) and filepath?
       argType = 'File Based'
       arg = filepath
+      editor.save()
     else
       argType = 'Selection Based'
       arg = selectedText


### PR DESCRIPTION
fix for issue #99 to save changes before script run on existing files. Since selection based runs from the buffer no changes there. If the file is unsaved the user will still have to save initially or do a selection based run with the appropriate grammar.
