### PR TITLE
Update RSpec example to use the recently released v3.0.x syntax

### DIFF
--- a/examples/bowling.rb
+++ b/examples/bowling.rb
@@ -1,0 +1,10 @@
+# From http://rspec.info
+
+class Bowling
+  def hit(pins)
+  end
+
+  def score
+    0
+  end
+end

--- a/examples/bowling_spec.rb
+++ b/examples/bowling_spec.rb
@@ -1,22 +1,11 @@
 # From http://rspec.info
 
-# bowling.rb
-class Bowling
-  def hit(pins)
-  end
-
-  def score
-    0
-  end
-end
-
-# bowling_spec.rb
-# require 'bowling'
+require_relative './bowling'
 
 describe Bowling, "#score" do
   it "returns 0 for all gutter game" do
     bowling = Bowling.new
     20.times { bowling.hit(0) }
-    bowling.score.should eq(0)
+    expect(bowling.score).to eq(0)
   end
 end


### PR DESCRIPTION
- [x] Separate Ruby and RSpec content
- [x] Update syntax to RSpec 3.0 which was recently released
