### PR TITLE
Add File Based PowerShell support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.8.0
+* Add Swift support
+* Add PowerShell support
+
 ## 2.7.0
 * The escape key will now close the script output pane
 * More tests, because this project definitely needs more tests

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You only have to add a few lines in a PR to support another.
 
 <sup>†</sup> Erlang uses `erl` for limited selection based runs (see [#70](https://github.com/rgbkrk/atom-script/pull/70))
 
-<sup>\*</sup> Cucumber (Gherkin), Go, F#, and Swift do not support selection based runs
+<sup>\*</sup> Cucumber (Gherkin), Go, F#, PowerShell, and Swift do not support selection based runs
 
 ## Installation
 

--- a/examples/hello_world.ps1
+++ b/examples/hello_world.ps1
@@ -1,0 +1,1 @@
+Write-Output "Hello World - From Script"

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -153,6 +153,11 @@ module.exports =
       command: "perl"
       args: (context) -> [context.filepath]
 
+  PowerShell:
+    "File Based":
+      command: "powershell"
+      args: (context) -> [context.filepath]
+
   Python:
     "Selection Based":
       command: "python"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "newLISP",
     "Perl",
     "PHP",
+    "PowerShell",
     "Python",
     "RSpec",
     "Ruby",


### PR DESCRIPTION
While testing #166 I ended up using PowerShell at one point by using a different grammar and selecting the `powershell` command. I noticed that using `powershell -Command 'Write-Output "Hello World"'` didn't work as expected so I left out `Selection Based` support for now.
