### PR TITLE
Removed -i option for swift. It is no longer valid.

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -238,4 +238,4 @@ module.exports =
   Swift:
     "File Based":
       command: "xcrun"
-      args: (context) -> ['swift', '-i', context.filepath]
+      args: (context) -> ['swift', context.filepath]


### PR DESCRIPTION
-i was removed in the latest versions of the swift compiler. The swift functionality in your plugin will now work correctly again.
