### PR TITLE
Batch Support

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -18,6 +18,11 @@ module.exports =
       command: "behat"
       args: (context) -> ['--ansi', context.fileColonLine()]
 
+  Batch:
+    "File Based":
+      command: ""
+      args: (context) -> [context.filepath]
+
   CoffeeScript:
     "Selection Based":
       command: "coffee"


### PR DESCRIPTION
Uses a blank command to launch the batch script. I found with batch that if you try to use start, /run or any of the other Windows related commands it would open a new Command Prompt. Since it appears it was launching from the command prompt already, just providing a blank command followed by the script will launch the script inside of atom.  
