### PR TITLE
Rename "Line Based runs" to "Line Number Based runs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.12.0
+* Rename "Line Based runs" to "Line Number Based runs"
+
 ## 2.11.0
 * Add Batch support
 
@@ -8,7 +11,7 @@
 * Fix Swift against Xcode Beta 5
 
 ## 2.9.0
-* Add LilyPond support 
+* Add LilyPond support
 * Add "Ruby on Rails" support
 * Add Makefile support
 * Now handling shebangs!
@@ -88,17 +91,17 @@
 * Added Groovy support
 * Added Scala support
 
-##2.0.4
+## 2.0.4
 * Added file based Haskell support
 
-##2.0.3
+## 2.0.3
 * Escaped ANSI to HTML
 * Added contributors to package.json
 
-##2.0.1-2.0.2
+## 2.0.1-2.0.2
 * Documentation patches
 
-##2.0.0
+## 2.0.0
 - Completely new UI
 - Status indicators / icons for script run, stop, kill, complete
 - Updated commands to kill process and dismiss script view

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Script [![Build Status](http://img.shields.io/travis/rgbkrk/atom-script.svg?style=flat)](https://travis-ci.org/rgbkrk/atom-script)
 **Run code in Atom!**
 
-Run scripts based on file name, a selection of code, or line number.
+Run scripts based on file name, a selection of code, or by line number.
 
 ![](https://cloud.githubusercontent.com/assets/1694055/3226201/c458acbc-f067-11e3-84a0-da27fe334f5e.gif)
 
@@ -71,7 +71,7 @@ Make sure to run `atom` from the command line to get full access to your environ
 
 **Script: Run** while text is selected will perform a "Selection Based" run executing just the highlighted code.
 
-**Script: Run at Line** to run using the specified line number. **Note** that if you select an entire line this number could be off by one due to the way Atom detects numbers while text is selected.
+**Script: Run by Line Number** to run using the specified line number. **Note** that if you select an entire line this number could be off by one due to the way Atom detects numbers while text is selected.
 
 **Script: Run Options** should be used to configure command options, program arguments, and environment variables overrides. Environment variables may be input into the options view in the form `VARIABLE_NAME_ONE=value;VARIABLE_NAME_TWO="other value";VARIABLE_NAME_3='test'`
 
@@ -84,13 +84,13 @@ coding.
 
 ### Command and shortcut reference
 
-| Command              | Mac OS X                            | Linux/Windows               | Notes                                                                         |
-|----------------------|-------------------------------------|-----------------------------|-------------------------------------------------------------------------------|
-| Script: Run          | <kbd>cmd-i</kbd>                    | <kbd>ctrl-b</kbd>           | If text is selected a "Selection Based" is used instead of a "File Based" run |
-| Script: Run at Line  | <kbd>shift-cmd-j</kbd>              | <kbd>shift-ctrl-j</kbd>      | If text is selected the line number will be the last                          |
-| Script: Run Options  | <kbd>shift-cmd-i</kbd>              | <kbd>shift-ctrl-alt-o</kbd> | Runs the selection or whole file with the given options                       |
-| Script: Close View   | <kbd>esc</kbd> or <kbd>ctrl-w</kbd> | <kbd>esc</kbd>              | Closes the script view window                                                 |
-| Script: Kill Process | <kbd>ctrl-c</kbd>                   | <kbd>ctrl-q</kbd>           | Kills the current script process                                              |
+| Command                    | Mac OS X                            | Linux/Windows               | Notes                                                                         |
+|----------------------------|-------------------------------------|-----------------------------|-------------------------------------------------------------------------------|
+| Script: Run                | <kbd>cmd-i</kbd>                    | <kbd>ctrl-b</kbd>           | If text is selected a "Selection Based" is used instead of a "File Based" run |
+| Script: Run by Line Number | <kbd>shift-cmd-j</kbd>              | <kbd>shift-ctrl-j</kbd>     | If text is selected the line number will be the last                          |
+| Script: Run Options        | <kbd>shift-cmd-i</kbd>              | <kbd>shift-ctrl-alt-o</kbd> | Runs the selection or whole file with the given options                       |
+| Script: Close View         | <kbd>esc</kbd> or <kbd>ctrl-w</kbd> | <kbd>esc</kbd>              | Closes the script view window                                                 |
+| Script: Kill Process       | <kbd>ctrl-c</kbd>                   | <kbd>ctrl-q</kbd>           | Kills the current script process                                              |
 
 ## Development
 

--- a/keymaps/script.cson
+++ b/keymaps/script.cson
@@ -7,7 +7,7 @@
   #'shift-enter': 'script:run'
   'ctrl-w': 'script:close-view'
   'ctrl-c': 'script:kill-process'
-  'shift-cmd-j': 'script:run-at-line'
+  'shift-cmd-j': 'script:run-by-line-number'
   'shift-cmd-i': 'script:run-options'
 
 '.platform-win32 .editor, .platform-linux .editor':
@@ -15,5 +15,5 @@
   #'shift-enter': 'script:run'
   #'ctrl-w': 'script:close-view'
   'ctrl-q': 'script:kill-process'
-  'shift-ctrl-j': 'script:run-at-line'
+  'shift-ctrl-j': 'script:run-by-line-number'
   'shift-ctrl-alt-o': 'script:run-options'

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -14,7 +14,7 @@ module.exports =
     "File Based":
       command: "behat"
       args: (context) -> ['--ansi', context.filepath]
-    "Line Based":
+    "Line Number Based":
       command: "behat"
       args: (context) -> ['--ansi', context.fileColonLine()]
 
@@ -61,7 +61,7 @@ module.exports =
     "File Based":
       command: "cucumber"
       args: (context) -> ['--color', context.filepath]
-    "Line Based":
+    "Line Number Based":
       command: "cucumber"
       args: (context) -> ['--color', context.fileColonLine()]
 
@@ -188,7 +188,7 @@ module.exports =
     "File Based":
       command: "rspec"
       args: (context) -> ['--tty', '--color', context.filepath]
-    "Line Based":
+    "Line Number Based":
       command: "rspec"
       args: (context) -> ['--tty', '--color', context.fileColonLine()]
 

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -24,7 +24,7 @@ class ScriptView extends View
   initialize: (serializeState, @runOptions) ->
     # Bind commands
     atom.workspaceView.command 'script:run', => @defaultRun()
-    atom.workspaceView.command 'script:run-at-line', => @lineRun()
+    atom.workspaceView.command 'script:run-by-line-number', => @lineRun()
     atom.workspaceView.command 'script:close-view', => @close()
     atom.workspaceView.command 'script:kill-process', => @stop()
 
@@ -68,7 +68,7 @@ class ScriptView extends View
 
   lineRun: ->
     @resetView()
-    codeContext = @buildCodeContext('Line Based')
+    codeContext = @buildCodeContext('Line Number Based')
     @start(codeContext) unless not codeContext?
 
   defaultRun: ->
@@ -86,13 +86,13 @@ class ScriptView extends View
 
     codeContext.argType = argType
 
-    if argType == 'Line Based'
+    if argType == 'Line Number Based'
       editor.save()
     else if codeContext.selection.isEmpty() and codeContext.filepath?
       codeContext.argType = 'File Based'
       editor.save()
 
-    # Selection and Line Based runs both benefit from knowing the current line
+    # Selection and Line Number Based runs both benefit from knowing the current line
     # number
     unless argType == 'File Based'
       cursor = editor.getCursor()
@@ -186,7 +186,7 @@ class ScriptView extends View
       return false
 
     # Update header to show the lang and file name
-    if codeContext.argType is 'Line Based'
+    if codeContext.argType is 'Line Number Based'
       @headerView.title.text "#{codeContext.lang} - #{codeContext.fileColonLine(false)}"
     else
       @headerView.title.text "#{codeContext.lang} - #{codeContext.filename}"

--- a/menus/script.cson
+++ b/menus/script.cson
@@ -1,7 +1,7 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
   '.line-number':
-    'Script: Run At Line': 'script:run-at-line'
+    'Script: Run by line number': 'script:run-by-line-number'
   '.overlayer':
     'Enable script': 'script:run-selection'
 
@@ -11,7 +11,7 @@
     'submenu': [
       'label': 'Script'
       'submenu': [
-        { 'label': 'Script: Run At Line', 'command': 'script:run-at-line' },
+        { 'label': 'Script: Run by Line Number', 'command': 'script:run-by-line-number' },
         { 'label': 'Run Script', 'command': 'script:run' },
         { 'label': 'Stop Script', 'command': 'script:kill-process' },
         { 'label': 'Configure Script', 'command': 'script:run-options' }


### PR DESCRIPTION
Multiple misconceptions with the name chosen for Line Number Based runs have occurred. See #155 and #197.
