### PR TITLE
Remove useless class

### DIFF
--- a/lib/script-options-view.coffee
+++ b/lib/script-options-view.coffee
@@ -12,31 +12,31 @@ class ScriptOptionsView extends View
             @label 'Current Working Directory:'
             @input
               type: 'text'
-              class: 'editor mini editor-colors native-key-bindings'
+              class: 'editor mini native-key-bindings'
               outlet: 'inputCwd'
           @div class: 'block', =>
             @label 'Command'
             @input
               type: 'text'
-              class: 'editor mini editor-colors native-key-bindings'
+              class: 'editor mini native-key-bindings'
               outlet: 'inputCommand'
           @div class: 'block', =>
             @label 'Command Arguments:'
             @input
               type: 'text'
-              class: 'editor mini editor-colors native-key-bindings'
+              class: 'editor mini native-key-bindings'
               outlet: 'inputCommandArgs'
           @div class: 'block', =>
             @label 'Program Arguments:'
             @input
               type: 'text'
-              class: 'editor mini editor-colors native-key-bindings'
+              class: 'editor mini native-key-bindings'
               outlet: 'inputScriptArgs'
           @div class: 'block', =>
             @label 'Environment Variables:'
             @input
               type: 'text'
-              class: 'editor mini editor-colors native-key-bindings'
+              class: 'editor mini native-key-bindings'
               outlet: 'inputEnv'
           @div class: 'block', =>
             css = 'btn inline-block-tight'


### PR DESCRIPTION
Hi there! The `.editor-colors` selector defines `color` and `background-color`, but those values have less precedence than those for `.editor.mini`. So using all three classes together makes `editor-colors` useless.

I noticed that the current code with `editor-colors` conflicts with [Zen](https://github.com/defunkt/zen), making the background color in Zen mode incorrect.

---

A more elaborated refactor might be using `TextEditorView(mini: true)` subviews instead of `input` elements, in the same way that [SelectListView](https://github.com/atom/atom/blob/master/src/select-list-view.coffee#L37) does, and then change the way we read the settings to something like [this](https://github.com/atom/atom/blob/master/src/select-list-view.coffee#L160-L161). But, perhaps, all this would be just overkill.
