### PR TITLE
Fix #238 - Convert ANSI codes even with escapeConsoleOutput unset

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -21,9 +21,6 @@ class ScriptView extends View
       @div class: css, outlet: 'script', tabindex: -1, =>
         @div class: 'panel-body padded output', outlet: 'output'
 
-  configDefaults:
-    escapeConsoleOutput: true
-
   initialize: (serializeState, @runOptions) ->
     # Bind commands
     atom.workspaceView.command 'script:run', => @defaultRun()
@@ -265,7 +262,8 @@ class ScriptView extends View
   display: (css, line) ->
     if atom.config.get('script.escapeConsoleOutput')
       line = _.escape(line)
-      line = @ansiFilter.toHtml(line)
+
+    line = @ansiFilter.toHtml(line)
 
     @output.append $$ ->
       @pre class: "line #{css}", =>

--- a/lib/script.coffee
+++ b/lib/script.coffee
@@ -9,6 +9,10 @@ module.exports =
       title: 'Output the time it took to execute the script'
       type: 'boolean'
       default: true
+    escapeConsoleOutput:
+      title: 'HTML escape console output'
+      type: 'boolean'
+      default: true
 
   scriptView: null
   scriptOptionsView: null


### PR DESCRIPTION
Fix #238 by:
- Setting the default  `script.escapeConsoleOutput` value in the same place as https://github.com/rgbkrk/atom-script/pull/225 (`Script` top level)
- Revert to the original conditional as proposed by @morinmorin (this converts ANSI codes to HTML regardless of the `script.escapeConsoleOutput` option.
