### PR TITLE
Nullify bufferedProcess when done

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -260,10 +260,11 @@ class ScriptView extends View
 
   stop: ->
     # Kill existing process if available
-    if @bufferedProcess? and @bufferedProcess.process?
+    if @bufferedProcess?
       @display 'stdout', '^C'
       @headerView.setStatus 'kill'
       @bufferedProcess.kill()
+      @bufferedProcess = null
 
   display: (css, line) ->
     if atom.config.get('script.escapeConsoleOutput')


### PR DESCRIPTION
After running the process, `bufferedProcess` variable is never cleared. This for example causes the kill block to get executed if script has exited or failed to run and we press ESC to close the view. This is because internally `bufferedProcess.process` is not cleared in these scenarios (it is only when we call bufferedProcess.kill()).

This is not causing any particular issues, but `bufferedProcess.process` also doesn't seem to be a public member of the interface and usage can be avoided by clearing the variable.
