### PR TITLE
[C++] Replace -Wc++11-extensions by -std=c++11

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -187,7 +187,7 @@ module.exports =
     if GrammarUtils.OperatingSystem.isDarwin()
       "File Based":
         command: "bash"
-        args: (context) -> ['-c', "xcrun clang++ -fcolor-diagnostics -Wc++11-extensions -Wall -include stdio.h -include iostream -framework Cocoa " + context.filepath + " -o /tmp/objc-cpp.out && /tmp/objc-cpp.out"]
+        args: (context) -> ['-c', "xcrun clang++ -fcolor-diagnostics -std=c++11 -Wall -include stdio.h -include iostream -framework Cocoa " + context.filepath + " -o /tmp/objc-cpp.out && /tmp/objc-cpp.out"]
 
   PHP:
     "Selection Based":


### PR DESCRIPTION
C++11 mode should be invoked using `-std=c++11` instead of `-Wc++11-extensions`, which gives warnings.

Source: http://clang.llvm.org/cxx_status.html
