### PR TITLE
Automate contributors & assist changelog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -51,3 +51,4 @@ jbtule <jay+code@tuley.name>  jbtule <jay+code@tuley.name>
 kami <kami30k@gmail.com>  kami <kami30k@gmail.com> 
 liamdawson <dawmail333@gmail.com>  liamdawson <dawmail333@gmail.com> 
 morinmorin <mimomorin@gmail.com>  morinmorin <mimomorin@gmail.com> 
+icedvariables <macodeblacko@gmail.com> macodeblacko@gmail.com <=>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,53 @@
+Alexey Slaykovsky <alexey@macbook.dlink>  Alexey Slaykovsky <alexey@macbook.dlink> 
+Andy Hayden <andyhayden1@gmail.com>  Andy Hayden <andyhayden1@gmail.com> 
+Ash Wilson <smashwilson@gmail.com>  Ash Wilson <smashwilson@gmail.com> 
+Calvin Bottoms <calvin.bottoms@gmail.com>  Calvin Bottoms <calvin.bottoms@gmail.com> 
+Calyhre <charley.david@wopata.com>  Calyhre <charley.david@wopata.com> 
+Christian Kjaer Laustsen <christianlaustsen@gmail.com>  Christian Kjaer Laustsen <christianlaustsen@gmail.com> 
+Ciaran Downey <me@ciarand.me>  Ciaran Downey <me@ciarand.me> 
+Dan <daniel.bayley@me.com>  Dan <daniel.bayley@me.com> 
+Daniel Bayley <daniel.bayley@me.com>  Daniel Bayley <daniel.bayley@me.com> 
+Daniel Chatfield <chatfielddaniel@gmail.com>  Daniel Chatfield <chatfielddaniel@gmail.com> 
+Dustin Blackman <dustinblackman@users.noreply.github.com>  Dustin Blackman <dustinblackman@users.noreply.github.com> 
+Erran Carey <me@errancarey.com>  Erran Carey <me@errancarey.com> 
+Florian Lefèvre <zedentox@gmail.com>  Florian Lefèvre <zedentox@gmail.com> 
+Hans Rødtang <hansrodtang@gmail.com>  Hans Rødtang <hansrodtang@gmail.com> 
+Hikaru Ojima <hikaru.ojima@mixi.co.jp>  Hikaru Ojima <hikaru.ojima@mixi.co.jp> 
+Ilya Palkin <ilya1984@ukr.net>  Ilya Palkin <ilya1984@ukr.net> 
+Ivan Storck <ivanoats@gmail.com>  Ivan Storck <ivanoats@gmail.com> 
+Jake Sankey <jakesankey@icloud.com>  Jake Sankey <jakesankey@icloud.com> 
+Johan Bruning <johan@taquito.nl>  Johan Bruning <johan@taquito.nl> 
+Kyle Kelley <rgbkrk@gmail.com>  Kyle Kelley <kyle.kelley@rackspace.com> 
+Kyle Kelley <rgbkrk@gmail.com>  Kyle Kelley <rgbkrk@gmail.com> 
+Kyle Kelley <rgbkrk@gmail.com>  rgbkrk <rgbkrk@gmail.com> 
+Lance Batson <lancebatsondev@gmail.com>  Lance Batson <intothev01d@users.noreply.github.com> 
+Lance Batson <lancebatsondev@gmail.com>  Lance Batson <lancebatsondev@gmail.com> 
+Lance Batson <lancebatsondev@gmail.com>  Lance Batson <lbatson@my.apsu.edu> 
+Liam Dawson <liam@liamdawson.me>  Liam Dawson <liam@liamdawson.me> 
+Lucas Magno <lmagno94@gmail.com>  Lucas Magno <lmagno94@gmail.com> 
+Marek Piechut <marek.piechut@gmail.com>  Marek Piechut <marek.piechut@gmail.com> 
+Mirek Rusin <mirek@me.com>  Mirek Rusin <mirek@me.com> 
+Otto Robba <OttoRobba@users.noreply.github.com>  Otto Robba <OttoRobba@users.noreply.github.com> 
+Pedro Rodriguez <ski.rodriguez@gmail.com>  Pedro Rodriguez <ski.rodriguez@gmail.com> 
+Rafael Belvederese <rafael@blvz.im>  Rafael Belvederese <rafael@blvz.im> 
+Rnhmjoj <micheleguerinirocco@me.com>  Rnhmjoj <micheleguerinirocco@me.com> 
+Rodolfo Carvalho <rhcarvalho@gmail.com>  Rodolfo Carvalho <rhcarvalho@gmail.com> 
+Sagi <saginedunkanal@users.noreply.github.com>  Sagi <saginedunkanal@users.noreply.github.com> 
+Sergey Koshelev <xih@yandex.ru>  Sergey Koshelev <xih@yandex.ru> 
+ThiconZ <xennma@outlook.com>  ThiconZ <ThiconZ@users.noreply.github.com> 
+ThiconZ <xennma@outlook.com>  ThiconZ <xennma@outlook.com> 
+Tomasz Grodzki <dev@plain.pl>  Tomasz Grodzki <dev@plain.pl> 
+Will Sahatdjian <ws@kindwave.com>  Will Sahatdjian <ws@kindwave.com> 
+Yeonghoon Park <sola92@gmail.com>  Yeonghoon Park <sola92@gmail.com> 
+benjamin <benjamin.nave@gmail.com>  benjamin <benjamin.nave@gmail.com> 
+bryanweatherly <bryanweatherly@gmail.com>  bryanweatherly <bryanweatherly@gmail.com> 
+cdingpeng <cdingpeng@glitchsoft.com>  cdingpeng <cdingpeng@glitchsoft.com> 
+cormullion <cormullion@mac.com>  cormullion <cormullion@mac.com> 
+dev <dev@debian7devel>  dev <dev@debian7devel> 
+elclanrs <cedric.ruiz@spacirdesigns.com>  elclanrs <cedric.ruiz@spacirdesigns.com> 
+fazo96 <fazius2009@gmail.com>  fazo96 <fazius2009@gmail.com> 
+gerane <gerane@gmail.com>  gerane <gerane@gmail.com> 
+jbtule <jay+code@tuley.name>  jbtule <jay+code@tuley.name> 
+kami <kami30k@gmail.com>  kami <kami30k@gmail.com> 
+liamdawson <dawmail333@gmail.com>  liamdawson <dawmail333@gmail.com> 
+morinmorin <mimomorin@gmail.com>  morinmorin <mimomorin@gmail.com> 

--- a/package.json
+++ b/package.json
@@ -6,41 +6,158 @@
   "description": "Run code in Atom!",
   "author": "Kyle Kelley <rgbkrk@gmail.com>",
   "contributors": [
-    "Kyle Kelley <rgbkrk@gmail.com>",
-    "Erran Carey <me@errancarey.com>",
-    "Lance Batson <lancebatsondev@gmail.com>",
-    "Pedro Rodriguez <ski.rodriguez@gmail.com>",
-    "Ash Wilson <smashwilson@gmail.com>",
-    "Hans Rødtang <hansrodtang@gmail.com>",
-    "Ciaran Downey <me@ciarand.me>",
-    "Hikaru Ojima <hikaru.ojima@mixi.co.jp>",
-    "Rafael Belvederese <rafael@blvz.im>",
-    "Ivan Storck <ivanoats@gmail.com>",
-    "Florian Lefèvre <zedentox@gmail.com>",
-    "Alexey Slaykovsky <alexey@macbook.dlink>",
-    "Christian Kjaer Laustsen <christianlaustsen@gmail.com>",
-    "Otto Robba <OttoRobba@users.noreply.github.com>",
-    "Will Sahatdjian <ws@kindwave.com>",
-    "Rnhmjoj <micheleguerinirocco@me.com>",
-    "Yeonghoon Park <sola92@gmail.com>",
-    "cormullion <cormullion@mac.com>",
-    "Dan <daniel.bayley@me.com>",
-    "Andy Hayden <andyhayden1@gmail.com>",
-    "jbtule <jay+code@tuley.name>",
-    "Jake Sankey <jakesankey@icloud.com>",
-    "bryanweatherly <bryanweatherly@gmail.com>",
-    "Johan Bruning <johan@taquito.nl>",
-    "Charley David <calyhre@gmail.com>",
-    "gerane <gerane@gmail.com>",
-    "Calvin Bottoms <calvin.bottoms@gmail.com>",
-    "Marek Piechut <marek.piechut@gmail.com>",
-    "Rodolfo Carvalho <rhcarvalho@gmail.com>",
-    "cdingpeng <cdingpeng@glitchsoft.com>",
-    "elclanrs <cedric.ruiz@spacirdesigns.com>",
-    "Sergey Koshelev <xih@yandex.ru>",
-    "Dustin Blackman <dustinblackman@users.noreply.github.com>",
-    "Daniel Chatfield <chatfielddaniel@gmail.com>",
-    "ThiconZ <ThiconZ@users.noreply.github.com>"
+    {
+      "name": "Kyle Kelley",
+      "email": "rgbkrk@gmail.com"
+    },
+    {
+      "name": "Erran Carey",
+      "email": "me@errancarey.com"
+    },
+    {
+      "name": "Florian Lefèvre",
+      "email": "zedentox@gmail.com"
+    },
+    {
+      "name": "Dustin Blackman",
+      "email": "dustinblackman@users.noreply.github.com"
+    },
+    {
+      "name": "elclanrs",
+      "email": "cedric.ruiz@spacirdesigns.com"
+    },
+    {
+      "name": "cdingpeng",
+      "email": "cdingpeng@glitchsoft.com"
+    },
+    {
+      "name": "gerane",
+      "email": "gerane@gmail.com"
+    },
+    {
+      "name": "Jake Sankey",
+      "email": "jakesankey@icloud.com"
+    },
+    {
+      "name": "Daniel Bayley",
+      "email": "daniel.bayley@me.com"
+    },
+    {
+      "name": "Dan",
+      "email": "daniel.bayley@me.com"
+    },
+    {
+      "name": "Calyhre",
+      "email": "charley.david@wopata.com"
+    },
+    {
+      "name": "rgbkrk",
+      "email": "rgbkrk@gmail.com"
+    },
+    {
+      "name": "Otto Robba",
+      "email": "OttoRobba@users.noreply.github.com"
+    },
+    {
+      "name": "Hikaru Ojima",
+      "email": "hikaru.ojima@mixi.co.jp"
+    },
+    {
+      "name": "Rafael Belvederese",
+      "email": "rafael@blvz.im"
+    },
+    {
+      "name": "Will Sahatdjian",
+      "email": "ws@kindwave.com"
+    },
+    {
+      "name": "Lance Batson",
+      "email": "lbatson@my.apsu.edu"
+    },
+    {
+      "name": "Ash Wilson",
+      "email": "smashwilson@gmail.com"
+    },
+    {
+      "name": "Pedro Rodriguez",
+      "email": "ski.rodriguez@gmail.com"
+    },
+    {
+      "name": "Hans Rødtang",
+      "email": "hansrodtang@gmail.com"
+    },
+    {
+      "name": "Yeonghoon Park",
+      "email": "sola92@gmail.com"
+    },
+    {
+      "name": "Johan Bruning",
+      "email": "johan@taquito.nl"
+    },
+    {
+      "name": "Andy Hayden",
+      "email": "andyhayden1@gmail.com"
+    },
+    {
+      "name": "Alexey Slaykovsky",
+      "email": "alexey@macbook.dlink"
+    },
+    {
+      "name": "Christian Kjaer Laustsen",
+      "email": "christianlaustsen@gmail.com"
+    },
+    {
+      "name": "cormullion",
+      "email": "cormullion@mac.com"
+    },
+    {
+      "name": "jbtule",
+      "email": "jay+code@tuley.name"
+    },
+    {
+      "name": "Ivan Storck",
+      "email": "ivanoats@gmail.com"
+    },
+    {
+      "name": "Ciaran Downey",
+      "email": "me@ciarand.me"
+    },
+    {
+      "name": "bryanweatherly",
+      "email": "bryanweatherly@gmail.com"
+    },
+    {
+      "name": "Rnhmjoj",
+      "email": "micheleguerinirocco@me.com"
+    },
+    {
+      "name": "Calvin Bottoms",
+      "email": "calvin.bottoms@gmail.com"
+    },
+    {
+      "name": "Marek Piechut",
+      "email": "marek.piechut@gmail.com"
+    },
+    {
+      "name": "Rodolfo Carvalho",
+      "email": "rhcarvalho@gmail.com"
+    },
+    {
+      "name": "Sergey Koshelev",
+      "email": "xih@yandex.ru"
+    },
+    {
+      "name": "Tomasz Grodzki",
+      "email": "dev@plain.pl"
+    },
+    {
+      "name": "fazo96",
+      "email": "fazius2009@gmail.com"
+    },
+    {
+      "name": "morinmorin",
+      "email": "mimomorin@gmail.com"
+    }
   ],
   "repository": "https://github.com/rgbkrk/atom-script",
   "keywords": [
@@ -86,6 +203,10 @@
     "atom-space-pen-views": "^2.0.3"
   },
   "devDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": "~0.4.5",
+    "nodegit": "^0.3.3"
+  },
+  "scripts": {
+    "prepublish": "node utils/updatePackage.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,38 @@
       "email": "me@errancarey.com"
     },
     {
+      "name": "ThiconZ",
+      "email": "ThiconZ@users.noreply.github.com"
+    },
+    {
+      "name": "Daniel Chatfield",
+      "email": "chatfielddaniel@gmail.com"
+    },
+    {
+      "name": "Lucas Magno",
+      "email": "lmagno94@gmail.com"
+    },
+    {
+      "name": "benjamin",
+      "email": "benjamin.nave@gmail.com"
+    },
+    {
+      "name": "liamdawson",
+      "email": "dawmail333@gmail.com"
+    },
+    {
+      "name": "Liam Dawson",
+      "email": "liam@liamdawson.me"
+    },
+    {
+      "name": "Ilya Palkin",
+      "email": "ilya1984@ukr.net"
+    },
+    {
+      "name": "kami",
+      "email": "kami30k@gmail.com"
+    },
+    {
       "name": "Florian Lefèvre",
       "email": "zedentox@gmail.com"
     },
@@ -157,6 +189,14 @@
     {
       "name": "morinmorin",
       "email": "mimomorin@gmail.com"
+    },
+    {
+      "name": "Mirek Rusin",
+      "email": "mirek@me.com"
+    },
+    {
+      "name": "Sagi",
+      "email": "saginedunkanal@users.noreply.github.com"
     }
   ],
   "repository": "https://github.com/rgbkrk/atom-script",

--- a/utils/updatePackage.js
+++ b/utils/updatePackage.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+var open = require("nodegit").Repository.open;
+var fs = require('fs');
+
+// node runtime is relative, whereas the package.json file is relative to cwd
+var pkg = require('../package.json')
+
+var authors = {}
+var rankings = {}
+
+var PREVIOUS_RELEASE_NOTE = new RegExp("^Prepare " + pkg["version"] + " release\s*");
+var accumulatedChanges = []
+var collecting = true;
+
+var ignore = {
+  "dev": "dev@debian7devel"
+}
+
+open(".")
+  .then(function(repo) {
+    return repo.getHeadCommit();
+  })
+  // Display information about commits at HEAD
+  .then(function(headCommit) {
+    // Create a new history event emitter.
+    var history = headCommit.history();
+  
+    // Listen for commit events from the history.
+    history.on("commit", function(commit) {
+      var author = commit.author();
+      var name = author.name();
+      var email = author.email();
+
+      var message = commit.message();
+
+      if (collecting) {
+        if(message.match(PREVIOUS_RELEASE_NOTE)){
+          collecting = false;
+        }
+        else {
+          accumulatedChanges.push(message);
+        }
+      }
+
+      if (! ( ignore[name] && ignore[name] === email )) {
+        // Take their most recent commit as the email they care about
+        // Assumes everyone has a unique name
+        authors[name] = authors[name] || email;
+        
+        // Count up their total number of commits
+        rankings[name] = rankings[name] || 0
+        rankings[name]++
+      }
+
+    });
+
+    history.on("end", function(commits) {
+
+      console.log("Summarize these for the CHANGELOG: ");
+      console.log(">>>>>>>>>>>>>>>");
+      for (var i = 0; i < accumulatedChanges.length; i++) {
+        console.log(accumulatedChanges[i]);
+      }
+      console.log("<<<<<<<<<<<<<<<");
+
+      // Create the updated contributors array
+      var contributors = []
+      for (var name in rankings) {
+        contributors.push({"name": name, "email": authors[name]})
+      }
+      pkg['contributors'] = contributors;
+
+      fs.writeFile("package.json", JSON.stringify(pkg, null, 2), function(err) {
+        if (err) {
+          console.err(err);
+        }
+        else {
+          console.log("package.json written");
+        }
+      });
+
+    });
+  
+    // Start emitting events.
+    history.start();
+  });
+

--- a/utils/updatePackage.js
+++ b/utils/updatePackage.js
@@ -13,7 +13,8 @@ var accumulatedChanges = []
 var collecting = true;
 
 var ignore = {
-  "dev": "dev@debian7devel"
+  "dev": "dev@debian7devel",
+  "=": "="
 }
 
 open(".")


### PR DESCRIPTION
Initial stabs at #255 and #254.

This modifies package.json in place before publishing. We may want to just use this as a manual command.

This outputs some information to summarize the CHANGELOG, using the messages from the commits that came after the most recent release:

```console
$ node utils/updatePackage.js
Summarize these for the CHANGELOG:
>>>>>>>>>>>>>>>
Newline at the end.

Update package.json, using name:, email: format

Summarize the CHANGELOG.

Clean up intermediary work.

Write out contributors to package.json

Put the update package in as a prepublish step.

Grab the most recent email to be used, rank devs

Initial stabbing at #254

Create CONTRIBUTING.md
Merge pull request #242 from erran/ansi-escape-modifications

Fix #238 - Convert ANSI codes even with escapeConsoleOutput unset
Fix #238 - Convert ANSI codes even with escapeConsoleOutput unset

* Update configuration defaults
* Revert the conditional escape logic to exclude the ANSI toHTML
statement (thanks for pointing this out @morinmorin)

<<<<<<<<<<<<<<<
package.json written
```

What do you think @erran? This requires nodegit.