### PR TITLE
Modify message when no language is selected

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -139,7 +139,7 @@ class ScriptView extends View
     # Determine if no language is selected.
     if lang is 'Null Grammar' or lang is 'Plain Text'
       err = $$ ->
-        @p 'You must select a language in the lower left, or save the file
+        @p 'You must select a language in the lower right, or save the file
           with an appropriate extension.'
 
     # Provide them a dialog to submit an issue on GH, prepopulated with their


### PR DESCRIPTION
[grammer-selector](https://github.com/atom/grammar-selector) 's position has been changed from left to right by default.

See also:

- [grammar-selector/lib/grammar-status-view.coffee](https://github.com/atom/grammar-selector/blob/533a86afa713df6e48a1d7454e93da783c8bc68c/lib/grammar-status-view.coffee#L16-L20)
- [grammar-selector/lib/main.coffee](https://github.com/atom/grammar-selector/blob/da7fceb8871196a29bc99cb32e58fa69eb35542b/lib/main.coffee#L7-L9)