### PR TITLE
Literate Haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Currently supported grammars are:
   * Julia
   * LilyPond
   * Lisp (via SBCL) <sup>[⍵](#omega)</sup>
+  * Literate Haskell <sup>[*](#asterisk)</sup>
   * LiveScript
   * Lua
   * Makefile
@@ -54,7 +55,7 @@ You only have to add a few lines in a PR to support another.
 
 <a name="dagger"></a><sup>†</sup> Erlang uses `erl` for limited selection based runs (see [#70](https://github.com/rgbkrk/atom-script/pull/70))
 
-<a name="asterisk"></a><sup>*</sup> Cucumber (Gherkin), Go, F#, PowerShell, Swift and D do not support selection based runs
+<a name="asterisk"></a><sup>*</sup> Cucumber (Gherkin), Go, F#, Literate Haskell, PowerShell, Swift and D do not support selection based runs
 
 <a name="omega"></a><sup>⍵</sup> Lisp selection based runs are limited to single line
 

--- a/examples/counting-numbers.lhs
+++ b/examples/counting-numbers.lhs
@@ -1,0 +1,6 @@
+This is a trivial program that prints an array.
+
+> f :: [Integer]
+> f = [1..10]
+> main :: IO ()
+> main = print f

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -145,6 +145,11 @@ module.exports =
       command: "sbcl"
       args: (context) -> ['--noinform', '--script', context.filepath]
 
+  'Literate Haskell':
+    "File Based":
+      command: "runhaskell"
+      args: (context) -> [context.filepath]
+
   LiveScript:
     "Selection Based":
       command: "lsc"


### PR DESCRIPTION
'Literate Haskell' key is used for *.lhs files.