### PR TITLE
F#: fsi.exe should be used in order to run F# code

### DIFF
--- a/examples/hello.fs
+++ b/examples/hello.fs
@@ -1,0 +1,7 @@
+namespace HelloWorld
+
+module Greeter =
+  let SayHelloTo name = printf "Hello %s!" name
+
+module Main =
+  Greeter.SayHelloTo "World"

--- a/examples/hello.fsx
+++ b/examples/hello.fsx
@@ -1,0 +1,2 @@
+let hello name = printfn "Hello %s!" name
+hello "World"

--- a/lib/grammar-utils/operating-system.coffee
+++ b/lib/grammar-utils/operating-system.coffee
@@ -4,5 +4,8 @@ module.exports =
   isDarwin: ->
     @platform() is 'darwin'
 
+  isWindows: ->
+    @platform() is 'win32'
+
   platform: ->
     process.platform

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -73,7 +73,7 @@ module.exports =
 
   'F#':
     "File Based":
-      command: "fsharpi"
+      command: if GrammarUtils.OperatingSystem.isWindows() then "fsi" else "fsharpi"
       args: (context) -> ['--exec', context.filepath]
 
   Gherkin:

--- a/spec/grammars-spec.coffee
+++ b/spec/grammars-spec.coffee
@@ -66,6 +66,29 @@ describe 'grammarMap', ->
         grammar = grammarMap['C++']
         expect(grammar).toBe(undefined)
 
+    describe 'F#', ->
+      it 'returns "fsi" as command for File Based runner on Windows', ->
+        OperatingSystem.platform = -> 'win32'
+        @reloadGrammar()
+
+        grammar = grammarMap['F#']
+        fileBasedRunner = grammar['File Based']
+        args = fileBasedRunner.args(@codeContext)
+        expect(fileBasedRunner.command).toEqual('fsi')
+        expect(args[0]).toEqual('--exec')
+        expect(args[1]).toEqual(@codeContext.filepath)
+
+      it 'returns "fsharpi" as command for File Based runner when platform is not Windows', ->
+        OperatingSystem.platform = -> 'darwin'
+        @reloadGrammar()
+
+        grammar = grammarMap['F#']
+        fileBasedRunner = grammar['File Based']
+        args = fileBasedRunner.args(@codeContext)
+        expect(fileBasedRunner.command).toEqual('fsharpi')
+        expect(args[0]).toEqual('--exec')
+        expect(args[1]).toEqual(@codeContext.filepath)
+
     describe 'Objective-C', ->
       it 'returns the appropriate File Based runner on Mac OS X', ->
         OperatingSystem.platform = -> 'darwin'


### PR DESCRIPTION
At least on Windows "fsi" is used instead of "fsharpi" right now.
http://fsharp.org/use/windows/

The compiler tools are installed at:
C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\fsc.exe
C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\fsi.exe
C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\fsiAnyCpu.exe
