### PR TITLE
Add a paste results option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Make sure to run `atom` from the command line to get full access to your environ
 To kill everything, click the close icon in the upper right and just go back to
 coding.
 
+**Script: Copy Run Results** copies everything written to the output pane to the
+clipboard, allowing you to paste it into the editor.
+
 ### Command and shortcut reference
 
 | Command                    | Mac OS X                            | Linux/Windows               | Notes                                                                         |

--- a/examples/color.py
+++ b/examples/color.py
@@ -2,14 +2,14 @@ def print_format_table():
     """
     prints table of formatted text format options
     """
-    for style in range(8):
-        for fg in range(30, 38):
+    for style in xrange(8):
+        for fg in xrange(30, 38):
             s1 = ''
-            for bg in range(40, 48):
+            for bg in xrange(40, 48):
                 format = ';'.join([str(style), str(fg), str(bg)])
                 s1 += '\x1b[%sm %s \x1b[0m' % (format, format)
-            print(s1)
-        print('\n')
+            print s1
+        print '\n'
 
 print("BEFORE")
 

--- a/examples/color.py
+++ b/examples/color.py
@@ -2,14 +2,14 @@ def print_format_table():
     """
     prints table of formatted text format options
     """
-    for style in xrange(8):
-        for fg in xrange(30, 38):
+    for style in range(8):
+        for fg in range(30, 38):
             s1 = ''
-            for bg in xrange(40, 48):
+            for bg in range(40, 48):
                 format = ';'.join([str(style), str(fg), str(bg)])
                 s1 += '\x1b[%sm %s \x1b[0m' % (format, format)
-            print s1
-        print '\n'
+            print(s1)
+        print('\n')
 
 print("BEFORE")
 

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -291,5 +291,4 @@ class ScriptView extends View
 
   pasteResults: ->
     if @results
-      console.log(@results)
       atom.workspace.getActiveEditor().insertText(@results)

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -28,7 +28,7 @@ class ScriptView extends View
     atom.workspaceView.command 'script:run-by-line-number', => @lineRun()
     atom.workspaceView.command 'script:close-view', => @close()
     atom.workspaceView.command 'script:kill-process', => @stop()
-    atom.workspaceView.command 'script:paste-results', => @pasteResults()
+    atom.workspaceView.command 'script:copy-run-results', => @copyResults()
 
     @ansiFilter = new AnsiFilter
 
@@ -289,6 +289,6 @@ class ScriptView extends View
       @pre class: "line #{css}", =>
         @raw line
 
-  pasteResults: ->
+  copyResults: ->
     if @results
-      atom.workspace.getActiveEditor().insertText(@results)
+      atom.clipboard.write @results

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -10,6 +10,7 @@ _ = require 'underscore'
 module.exports =
 class ScriptView extends View
   @bufferedProcess: null
+  @results: ""
 
   @content: ->
     @div =>
@@ -27,6 +28,7 @@ class ScriptView extends View
     atom.workspaceView.command 'script:run-by-line-number', => @lineRun()
     atom.workspaceView.command 'script:close-view', => @close()
     atom.workspaceView.command 'script:kill-process', => @stop()
+    atom.workspaceView.command 'script:paste-results', => @pasteResults()
 
     @ansiFilter = new AnsiFilter
 
@@ -125,6 +127,9 @@ class ScriptView extends View
 
     # Get script view ready
     @output.empty()
+
+    # Remove the old script results
+    @results = ""
 
   close: ->
     # Stop any running process and dismiss window
@@ -273,6 +278,8 @@ class ScriptView extends View
       @bufferedProcess = null
 
   display: (css, line) ->
+    @results += line
+
     if atom.config.get('script.escapeConsoleOutput')
       line = _.escape(line)
 
@@ -281,3 +288,8 @@ class ScriptView extends View
     @output.append $$ ->
       @pre class: "line #{css}", =>
         @raw line
+
+  pasteResults: ->
+    if @results
+      console.log(@results)
+      atom.workspace.getActiveEditor().insertText(@results)

--- a/menus/script.cson
+++ b/menus/script.cson
@@ -16,6 +16,7 @@
         { 'label': 'Stop Script', 'command': 'script:kill-process' },
         { 'label': 'Configure Script', 'command': 'script:run-options' }
         { 'label': 'Close Window and Stop Script', 'command': 'script:close-view' }
+        { 'label': 'Paste Results', 'command': 'script:paste-results' }
       ]
     ]
   }

--- a/menus/script.cson
+++ b/menus/script.cson
@@ -16,7 +16,7 @@
         { 'label': 'Stop Script', 'command': 'script:kill-process' },
         { 'label': 'Configure Script', 'command': 'script:run-options' }
         { 'label': 'Close Window and Stop Script', 'command': 'script:close-view' }
-        { 'label': 'Paste Results', 'command': 'script:paste-results' }
+        { 'label': 'Copy Run Results', 'command': 'script:copy-run-results' }
       ]
     ]
   }


### PR DESCRIPTION
Record all displayed results since the last run, and add a menu option to paste these results at the cursor.

I am experiencing an issue with this code though - if I run the `colors.py` example and paste into an new document, it works fine. If I then go and paste into the document I just ran, Atom locks up. I've never worked with atom internals before though, so I'm unsure where to look.