### PR TITLE
Lua Run Selected Lines Fix

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -166,7 +166,10 @@ module.exports =
   Lua:
     "Selection Based":
       command: "lua"
-      args: (context)  -> ['-e', context.getCode()]
+      args: (context) ->
+        code = context.getCode(true)
+        tmpFile = GrammarUtils.createTempFileWithCode(code)
+        [tmpFile]
     "File Based":
       command: "lua"
       args: (context) -> [context.filepath]
@@ -198,11 +201,6 @@ module.exports =
       "File Based":
         command: "bash"
         args: (context) -> ['-c', "xcrun clang++ -fcolor-diagnostics -Wc++11-extensions -Wall -include stdio.h -include iostream -framework Cocoa " + context.filepath + " -o /tmp/objc-cpp.out && /tmp/objc-cpp.out"]
-
-  ocaml:
-    "File Based":
-      command: "ocaml"
-      args: (context) -> [context.filepath]
 
   PHP:
     "Selection Based":

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -202,6 +202,11 @@ module.exports =
         command: "bash"
         args: (context) -> ['-c', "xcrun clang++ -fcolor-diagnostics -Wc++11-extensions -Wall -include stdio.h -include iostream -framework Cocoa " + context.filepath + " -o /tmp/objc-cpp.out && /tmp/objc-cpp.out"]
 
+  ocaml:
+      "File Based":
+        command: "ocaml"
+        args: (context) -> [context.filepath]
+        
   PHP:
     "Selection Based":
       command: "php"

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -203,10 +203,10 @@ module.exports =
         args: (context) -> ['-c', "xcrun clang++ -fcolor-diagnostics -Wc++11-extensions -Wall -include stdio.h -include iostream -framework Cocoa " + context.filepath + " -o /tmp/objc-cpp.out && /tmp/objc-cpp.out"]
 
   ocaml:
-      "File Based":
-        command: "ocaml"
-        args: (context) -> [context.filepath]
-        
+    "File Based":
+      command: "ocaml"
+      args: (context) -> [context.filepath]
+
   PHP:
     "Selection Based":
       command: "php"


### PR DESCRIPTION
Fixes #394, Run Selected Line(s) for Lua, by creating a temp file with the
selected lines and prepending blank lines to the temp file equal to the
number of lines above the selected source lines to match Lua error lines
numbers from the temp file with those of the source view.