### PR TITLE
Add Kotlin support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Currently supported grammars are:
   * Haskell
   * Javascript
   * Julia
+  * Kotlin
   * LilyPond
   * Lisp (via SBCL) <sup>[⍵](#omega)</sup>
   * Literate Haskell <sup>[*](#asterisk)</sup>

--- a/examples/hello.kt
+++ b/examples/hello.kt
@@ -1,0 +1,3 @@
+fun main(args: Array<String>) {
+    println("Hello, World!")
+}

--- a/lib/grammar-utils.coffee
+++ b/lib/grammar-utils.coffee
@@ -13,11 +13,11 @@ module.exports =
   # * `code`    A {String} containing some code
   #
   # Returns the {String} filepath of the new file
-  createTempFileWithCode: (code) ->
+  createTempFileWithCode: (code, extension = "") ->
     try
       fs.mkdirSync(@tempFilesDir) unless fs.existsSync(@tempFilesDir)
 
-      tempFilePath = @tempFilesDir + path.sep + uuid.v1()
+      tempFilePath = @tempFilesDir + path.sep + uuid.v1() + extension
 
       file = fs.openSync(tempFilePath, 'w')
       fs.writeSync(file, code)

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -140,14 +140,14 @@ module.exports =
       args: (context) ->
         code = context.getCode(true)
         tmpFile = GrammarUtils.createTempFileWithCode(code, ".kt")
-        jarName = context.filename.replace(/\.kt$/g, "") + ".jar"
-        args = ['-c', "kotlinc " + tmpFile + " -include-runtime -d " + jarName + " && java -jar " + jarName + " && rm " + jarName]
+        jarName = tmpFile.replace /\.kt$/, ".jar"
+        args = ['-c', "kotlinc #{tmpFile} -include-runtime -d #{jarName} && java -jar #{jarName} && rm #{jarName}"]
         return args
     "File Based":
       command: "bash"
       args: (context) ->
-        jarName = context.filename.replace(/\.kt$/g, "") + ".jar"
-        args = ['-c', "kotlinc " + context.filepath + " -include-runtime -d " + jarName + " && java -jar " + jarName + " && rm " + jarName]
+        jarName = context.filename.replace /\.kt$/, ".jar"
+        args = ['-c', "kotlinc #{context.filepath} -include-runtime -d #{jarName} && java -jar #{jarName} && rm #{jarName}"]
         return args
 
   LilyPond:

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -134,6 +134,22 @@ module.exports =
       command: "julia"
       args: (context) -> [context.filepath]
 
+  Kotlin:
+    "Selection Based":
+      command: "bash"
+      args: (context) ->
+        code = context.getCode(true)
+        tmpFile = GrammarUtils.createTempFileWithCode(code, ".kt")
+        jarName = context.filename.replace(/\.kt$/g, "") + ".jar"
+        args = ['-c', "kotlinc " + tmpFile + " -include-runtime -d " + jarName + " && java -jar " + jarName + " && rm " + jarName]
+        return args
+    "File Based":
+      command: "bash"
+      args: (context) ->
+        jarName = context.filename.replace(/\.kt$/g, "") + ".jar"
+        args = ['-c', "kotlinc " + context.filepath + " -include-runtime -d " + jarName + " && java -jar " + jarName + " && rm " + jarName]
+        return args
+
   LilyPond:
     "File Based":
       command: "lilypond"


### PR DESCRIPTION
Add default argument to createTempFileWithCode which accepts file
extension. Kotlin requires the correct file extension in order to
compile, and the temporary file for selection based execution does not
have a file extension.

Delete built jar after running. Other grammars don't seem to do any
clean up (Rust, Obj-c), but I'm not sure if this is intentional.