### PR TITLE
No more using atom.emit.

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -233,7 +233,6 @@ class ScriptView extends View
     @stop()
 
   run: (command, extraArgs, codeContext) ->
-    atom.emit 'achievement:unlock', msg: 'Homestar Runner'
     startTime = new Date()
 
     # Default to where the user opened atom


### PR DESCRIPTION
If we ever want to use Atom Achievements again ;), [they](https://github.com/rgbkrk/atom-achievements)'ll need to
update their use of the new message passing APIs.

Fixes #435.