### PR TITLE
Don't bother removing temp jar. Output to /tmp/.

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -141,13 +141,13 @@ module.exports =
         code = context.getCode(true)
         tmpFile = GrammarUtils.createTempFileWithCode(code, ".kt")
         jarName = tmpFile.replace /\.kt$/, ".jar"
-        args = ['-c', "kotlinc #{tmpFile} -include-runtime -d #{jarName} && java -jar #{jarName} && rm #{jarName}"]
+        args = ['-c', "kotlinc #{tmpFile} -include-runtime -d #{jarName} && java -jar #{jarName}"]
         return args
     "File Based":
       command: "bash"
       args: (context) ->
         jarName = context.filename.replace /\.kt$/, ".jar"
-        args = ['-c', "kotlinc #{context.filepath} -include-runtime -d #{jarName} && java -jar #{jarName} && rm #{jarName}"]
+        args = ['-c', "kotlinc #{context.filepath} -include-runtime -d /tmp/#{jarName} && java -jar /tmp/#{jarName}"]
         return args
 
   LilyPond:


### PR DESCRIPTION
I made some changes to the outputs for consistency. Now the jar is build to `/tmp` like the other compiler based scripts. Also, there's no need to call delete the jar in the temp directory for selection based scripts.