### PR TITLE
Add Java grammar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Currently supported grammars are:
   * Go <sup>[*](#asterisk)</sup>
   * Groovy
   * Haskell
+  * Java
   * Javascript
   * Julia
   * Kotlin

--- a/examples/HelloWorld.java
+++ b/examples/HelloWorld.java
@@ -1,0 +1,5 @@
+class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -123,7 +123,6 @@ module.exports =
       command: "bash"
       args: (context) ->
         className = context.filename.replace /\.java$/, ""
-        console.log(className)
         args = ['-c', "javac -d /tmp #{context.filepath} && java -cp /tmp #{className}"]
         return args
 

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -118,6 +118,15 @@ module.exports =
       command: "iced"
       args: (context) -> [context.filepath]
 
+  Java:
+    "File Based":
+      command: "bash"
+      args: (context) ->
+        className = context.filename.replace /\.java$/, ""
+        console.log(className)
+        args = ['-c', "javac -d /tmp #{context.filepath} && java -cp /tmp #{className}"]
+        return args
+
   JavaScript:
     "Selection Based":
       command: "node"


### PR DESCRIPTION
File-based Java scripts only for now. Selection-based scripts would
require naming the temp file to match the main class, and also finding
the main class in the selection. This could be done by passing in a file
name and searching for the first instance of `/class (.*)\{/`, but I don't
feel comfortable doing this without significant testing and suggestions
for the current contributors.