### PR TITLE
Fixed behat3 execution by removing --ansi parameter

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -16,10 +16,10 @@ module.exports =
   'Behat Feature':
     "File Based":
       command: "behat"
-      args: (context) -> ['--ansi', context.filepath]
+      args: (context) -> [context.filepath]
     "Line Number Based":
       command: "behat"
-      args: (context) -> ['--ansi', context.fileColonLine()]
+      args: (context) -> [context.fileColonLine()]
 
   Batch:
     "File Based":


### PR DESCRIPTION
Allow execution for behat 3 and behat 2.5 version. Closes #450.