### PR TITLE
add; babel javascript language support

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -130,6 +130,14 @@ module.exports =
     "File Based":
       command: "node"
       args: (context) -> [context.filepath]
+      
+  'Babel ES6 Javascript':
+    "Selection Based":
+      command: "babel-node"
+      args: (context) -> ['-e', context.getCode()]
+    "File Based":
+      command: "babel-node"
+      args: (context) -> [context.filepath]
 
   Julia:
     "Selection Based":


### PR DESCRIPTION
This will utilize the babel-node command if using the `language-babel` (https://atom.io/packages/language-babel)