### PR TITLE
Add DOT (Graphviz) grammar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently supported grammars are:
   * CoffeeScript (Literate) <sup>[^](#caret)</sup>
   * Cucumber (Gherkin) <sup>[*](#asterisk)</sup>
   * D <sup>[*](#asterisk)</sup>
+  * DOT (Graphviz)
   * Elixir
   * Erlang <sup>[†](#dagger)</sup>
   * F# <sup>[*](#asterisk)</sup>

--- a/examples/hello.dot
+++ b/examples/hello.dot
@@ -1,0 +1,5 @@
+# Taken from: http://en.wikipedia.org/wiki/DOT_(graph_description_language)
+digraph graphname {
+     a -> b -> c;
+     b -> d;
+}

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -63,6 +63,11 @@ module.exports =
       command: "rdmd"
       args: (context) -> [context.filepath]
 
+  DOT:
+    "File Based":
+      command: "dot"
+      args: (context) -> ['-Tpng', context.filepath, '-o', context.filepath + '.png']
+
   Elixir:
     "Selection Based":
       command: "elixir"


### PR DESCRIPTION
More information:
http://graphviz.org
http://en.wikipedia.org/wiki/DOT_(graph_description_language)
http://en.wikipedia.org/wiki/Graphviz

Example command, given a `.dot` file named "package_arch.dot":
```
dot -Tpng package_arch.dot -o package_arch.png
```