### PR TITLE
Fix typo in Perl 6 grammar name

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -268,7 +268,7 @@ module.exports =
       command: "perl"
       args: (context) -> [context.filepath]
 
-  Perl6:
+  "Perl 6":
     "Selection Based":
       command: "perl6"
       args: (context)  -> ['-e', context.getCode()]


### PR DESCRIPTION
Sorry. I was new to atom packages and did not test it.