### PR TITLE
Add C file based runner for linux

### DIFF
--- a/lib/grammar-utils/operating-system.coffee
+++ b/lib/grammar-utils/operating-system.coffee
@@ -7,5 +7,8 @@ module.exports =
   isWindows: ->
     @platform() is 'win32'
 
+  isLinux: ->
+    @platform() is 'linux'
+
   platform: ->
     process.platform

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -30,6 +30,10 @@ module.exports =
       "File Based":
         command: "bash"
         args: (context) -> ['-c', "xcrun clang -fcolor-diagnostics -Wall -include stdio.h '" + context.filepath + "' -o /tmp/c.out && /tmp/c.out"]
+    else if GrammarUtils.OperatingSystem.isLinux()
+      "File Based":
+        command: "bash"
+        args: (context) -> ["-c", "cc -Wall -include stdio.h '" + context.filepath + "' -o /tmp/c.out && /tmp/c.out"]
 
   'C++':
     if GrammarUtils.OperatingSystem.isDarwin()


### PR DESCRIPTION
This PR is how I use the file based runner for C files under linux. Also addresses issue #454. This is essentially the same as the versions for darwin.

The compiler command could be explicitly set to `gcc`, but all systems I've worked on symlink `cc` to either `clang` or `gcc` via `/etc/alternatives`. The compiler flags are similar enough to work with both compilers.

