### PR TITLE
Add TypeScript support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Currently supported grammars are:
   * Sass/SCSS <sup>[*](#asterisk)</sup>
   * Scala
   * Swift
+  * TypeScript
 
 **NOTE**: Some grammars may require you to install [a custom language package](https://atom.io/search?utf8=✓&q=language).
 

--- a/examples/greeter.ts
+++ b/examples/greeter.ts
@@ -1,0 +1,10 @@
+class Greeter {
+  constructor(public greeting: string) { }
+  greet() {
+    return this.greeting;
+  }
+};
+
+var greeter = new Greeter("Hello, world!");
+
+console.log(greeter.greet());

--- a/examples/longrun.ts
+++ b/examples/longrun.ts
@@ -1,0 +1,11 @@
+var i: number = 1;
+var run = setInterval(function() {
+  console.log("line " + i);
+  i++;
+  if (i == 20) {
+    stop();
+  }
+}, 1000);
+function stop(): void {
+  clearInterval(run);
+}

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -431,3 +431,16 @@ module.exports =
     "File Based":
       command: "xcrun"
       args: (context) -> ['swift', context.filepath]
+
+  TypeScript:
+    "Selection Based":
+      command: "bash"
+      args: (context) ->
+        code = context.getCode(true)
+        tmpFile = GrammarUtils.createTempFileWithCode(code, ".ts")
+        jsFile = tmpFile.replace /\.ts$/, ".js"
+        args = ['-c', "tsc --out '#{jsFile}' '#{tmpFile}' && node '#{jsFile}'"]
+        return args
+    "File Based":
+      command: "bash"
+      args: (context) -> ['-c', "tsc '#{context.filepath}' --out /tmp/js.out && node /tmp/js.out"]


### PR DESCRIPTION
Hi there,

I've added support for TypeScript to your excellent atom-script plugin.  Currently it only works in Linux/OS X as it relies on bash, but with some modifications it could be reworked to support Windows if required.