### PR TITLE
Remove grandparent bottom-panel

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -140,7 +140,10 @@ class ScriptView extends View
   close: ->
     # Stop any running process and dismiss window
     @stop()
-    @detach() if @hasParent()
+    if @hasParent()
+      grandParent = @script.parent().parent()
+      @detach()
+      grandParent.remove()
 
   destroy: ->
     @subscriptions?.dispose()


### PR DESCRIPTION
This removes the grandparent `bottom-panel` on close of a script. Without doing so, the empty bottom-panels hang around and since each has a height of 1px, they start to stack up and take up more and more space.