### PR TITLE
Add ability to resize Script View

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -1,7 +1,7 @@
 grammarMap = require './grammars'
 
 {BufferedProcess, CompositeDisposable} = require 'atom'
-{View, $$} = require 'atom-space-pen-views'
+{View, $$, $} = require 'atom-space-pen-views'
 CodeContext = require './code-context'
 HeaderView = require './header-view'
 ScriptOptionsView = require './script-options-view'
@@ -17,6 +17,7 @@ class ScriptView extends View
 
   @content: ->
     @div =>
+      @div class: 'panel-resize-handle'
       @subview 'headerView', new HeaderView()
 
       # Display layout and outlets
@@ -36,7 +37,29 @@ class ScriptView extends View
       'script:run-by-line-number': => @lineRun()
       'script:run': => @defaultRun()
 
+    @handleEvents()
     @ansiFilter = new AnsiFilter
+
+  handleEvents: =>
+    @on 'mousedown', '.panel-resize-handle', (e) => @resizeStarted(e)
+
+  resizeStarted: =>
+    $(document).on('mousemove', @resizeScriptView)
+    $(document).on('mouseup', @resizeStopped)
+
+  resizeStopped: =>
+    $(document).off('mousemove', @resizeScriptView)
+    $(document).off('mouseup', @resizeStopped)
+
+  resizeScriptView: ({pageY, which}) =>
+    totalHeight  = $(document.body).height()
+    headerHeight = $(".header-view").height()
+    # FIXME(rodionovd): I don't know why this offset must be exactly 51px, but
+    # it seems to work. Sorry everyone.
+    magicOffset = 51
+    $(".script-view").css({
+        height: (totalHeight - pageY - headerHeight - magicOffset)
+    });
 
   serialize: ->
 

--- a/styles/script.less
+++ b/styles/script.less
@@ -40,10 +40,17 @@
   }
 }
 
+.panel-resize-handle {
+  position: relative;
+  height: 1pt;
+  cursor: row-resize;
+  z-index: 3;
+}
+
 .script-view {
   overflow: scroll;
-  max-height: 300px;
-  height: auto;
+  height: 200px;
+  min-height: 100px;
   margin-bottom: 0px;
 
   .panel-body pre{


### PR DESCRIPTION
Hi!  

Here's my attempt to make Script View resizable.

###### Long story short

I write code on a 13" laptop usually, so a constant-sized panel occupies lots of valuable and very limited screen space; thus it'd be great to have an ability to resize it. In this PR, I set 200px as a default height with a minimum of 100px.

> This feature was also suggested in #516, #267, #235 and #94.

###### Disclaimer

I'm *not* a JS/CoffeeScript developer by any means, so I've tried to find [some](https://github.com/atom/tree-view/) [examples](https://github.com/tcarlsen/atom-message-panel) of resizable Atom panels and then use the same techniques here for the `atom-script`'s panel.

I'd greatly appreciate any feedback on this PR.

Thanks! 😊
