### PR TITLE
Wrap file paths in clickable links

### DIFF
--- a/lib/link-paths.coffee
+++ b/lib/link-paths.coffee
@@ -1,0 +1,17 @@
+regex = /// (/?(?:[-\w.]+/)*[-\w.]+):(\d+):(\d+) ///g
+template = '<a class="-linked-path" data-path="$1" data-line="$2" data-column="$3">$&</a>'
+
+module.exports = linkPaths = (lines) ->
+  lines.replace regex, template
+
+linkPaths.listen = (parentView) ->
+  parentView.on 'click', '.-linked-path', (event) ->
+    el = this
+    {path, line, column} = el.dataset
+    line = Number(line)
+    column = Number(column)
+
+    atom.workspace.open path, {
+      initialLine: line
+      initialColumn: column
+      }

--- a/lib/link-paths.coffee
+++ b/lib/link-paths.coffee
@@ -8,10 +8,10 @@ linkPaths.listen = (parentView) ->
   parentView.on 'click', '.-linked-path', (event) ->
     el = this
     {path, line, column} = el.dataset
-    line = Number(line)
-    column = Number(column)
+    line = Number(line) - 1
+    column = Number(column) - 1
 
     atom.workspace.open path, {
       initialLine: line
       initialColumn: column
-      }
+    }

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -7,6 +7,7 @@ HeaderView = require './header-view'
 ScriptOptionsView = require './script-options-view'
 AnsiFilter = require 'ansi-to-html'
 stripAnsi = require 'strip-ansi'
+linkPaths = require './link-paths'
 _ = require 'underscore'
 
 # Runs a portion of a script through an interpreter and displays it line by line
@@ -37,6 +38,8 @@ class ScriptView extends View
       'script:run': => @defaultRun()
 
     @ansiFilter = new AnsiFilter
+
+    linkPaths.listen @
 
   serialize: ->
 
@@ -297,6 +300,7 @@ class ScriptView extends View
       line = _.escape(line)
 
     line = @ansiFilter.toHtml(line)
+    line = linkPaths(line)
 
     padding = parseInt(@output.css('padding-bottom'))
     scrolledToEnd =

--- a/spec/link-paths-spec.coffee
+++ b/spec/link-paths-spec.coffee
@@ -1,0 +1,19 @@
+linkPaths = require '../lib/link-paths'
+
+describe 'linkPaths', ->
+  it 'detects file paths with line numbers', ->
+    result = linkPaths 'foo() b/c.js:44:55'
+    expect(result).toContain 'foo() <a'
+    expect(result).toContain 'class="-linked-path"'
+    expect(result).toContain 'data-path="b/c.js"'
+    expect(result).toContain 'data-line="44"'
+    expect(result).toContain 'data-column="55"'
+    expect(result).toContain 'b/c.js:44:55'
+
+  it 'links multiple paths', ->
+    multilineResult = linkPaths """
+      foo() b/c.js:44:55
+      bar() b/c.js:45:56
+    """
+    expect(multilineResult).toContain 'foo() <a'
+    expect(multilineResult).toContain 'bar() <a'


### PR DESCRIPTION
![clickable-path-links](https://cloud.githubusercontent.com/assets/1083040/9296496/e26bbd72-4442-11e5-8d3c-bd2e64f42e62.gif)

Still a work in progress, but I'd love feedback.  Currently, it's enabled by default for all scripts.  Should users have the option to turn it on and off as a setting?

I've only tested the path parsing with V8 stack traces. 