### PR TITLE
Scroll down in a polling loop to catch the reflow

### DIFF
--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -310,7 +310,19 @@ class ScriptView extends View
 
     if atom.config.get('script.scrollWithOutput')
       if lessThanFull or scrolledToEnd
-        @script.scrollTop(@output.trueHeight())
+        # Scroll down in a polling loop 'cause
+        # we don't know when the reflow will finish.
+        # See: http://stackoverflow.com/q/5017923/407845
+        do @checkScrollAgain 5
+
+  scrollTimeout: null
+  checkScrollAgain: (times) ->
+    =>
+      @script.scrollToBottom()
+
+      clearTimeout @scrollTimeout
+      if times > 1
+        @scrollTimeout = setTimeout @checkScrollAgain(times - 1), 50
 
   copyResults: ->
     if @results


### PR DESCRIPTION
My script panel kept intermittently scrolling a few pixels short of all the way:
![not-all-the-way](https://cloud.githubusercontent.com/assets/1083040/9297101/b40ddf08-444e-11e5-9c4a-9f777349fb5e.gif)

This terrible hack fixes it for me:
![all-the-way](https://cloud.githubusercontent.com/assets/1083040/9297108/da34f61c-444e-11e5-8cef-1d97663c76db.gif)

The duration and frequency of polling may need to be tweaked for other folks' machines.  Inspired by [this SO post](http://stackoverflow.com/q/5017923/407845).

With space pen [on the way out](https://github.com/atom-archive/space-pen#spacepen-), and the future [pretty uncertain](https://github.com/atom/atom/issues/5756), I hope the next view stack makes this easy to fix robustly.

Are there other ways?
