### PR TITLE
Adds the extraPathEntries config setting

### DIFF
--- a/lib/script.coffee
+++ b/lib/script.coffee
@@ -17,6 +17,13 @@ module.exports =
       title: 'Scroll with output'
       type: 'boolean'
       default: true
+    extraPathEntries:
+      title: 'Add these directories to the PATH environment variable'
+      description: 'Comma separated list of paths'
+      type: 'array'
+      items:
+        type: 'string'
+      default: []
   scriptView: null
   scriptOptionsView: null
   scriptOptions: null


### PR DESCRIPTION
This allows users to add extra directories to the PATH environment variable used to run scripts.

Demo:
![atom-script](https://cloud.githubusercontent.com/assets/306982/9429863/9f7a3fe2-4993-11e5-95d0-6459534c2a24.gif)

