### PR TITLE
Runner behavior refactoring

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -1,0 +1,88 @@
+{Emitter, BufferedProcess} = require 'atom'
+
+module.exports =
+class Runner
+  bufferedProcess: null
+
+  constructor: (@runOptions, @emitter = new Emitter) ->
+
+  run: (command, extraArgs, codeContext) ->
+    @startTime = new Date()
+    @command = command
+
+    args = @args(codeContext, extraArgs)
+    exit = @onExit
+    stdout = @stdoutFunc
+    stderr = @stderrFunc
+    options = @options()
+
+    @bufferedProcess = new BufferedProcess({
+      command, args, options, stdout, stderr, exit
+    })
+
+    @stdinFunc(@bufferedProcess.process.stdin) if @stdinFunc
+
+    @bufferedProcess.onWillThrowError(@createOnErrorFunc(command))
+
+  stdoutFunc: (output) =>
+    @emitter.emit 'did-write-to-stdout', { message: output }
+
+  onDidWriteToStdout: (callback) =>
+    @emitter.on 'did-write-to-stdout', callback
+
+  stderrFunc: (output) =>
+    @emitter.emit 'did-write-to-stderr', { message: output }
+
+  onDidWriteToStderr: (callback) =>
+    @emitter.on 'did-write-to-stderr', callback
+
+  stdinFunc: null
+
+  destroy: ->
+    @eitter.dispose()
+
+  getCwd: ->
+    cwd = @runOptions.workingDirectory
+
+    workingDirectoryProvided = cwd? and cwd isnt ''
+    paths = atom.project.getPaths()
+    if not workingDirectoryProvided and paths?.length > 0
+      cwd = paths[0]
+
+    cwd
+
+  stop: ->
+    if @bufferedProcess?
+      @bufferedProcess.kill()
+      @bufferedProcess = null
+
+  onExit: (returnCode) =>
+    @bufferedProcess = null
+
+    if (atom.config.get 'script.enableExecTime') is true and @startTime
+      executionTime = (new Date().getTime() - @startTime.getTime()) / 1000
+
+    @emitter.emit 'did-exit', { executionTime: executionTime, returnCode: returnCode }
+
+  onDidExit: (callback) =>
+    @emitter.on 'did-exit', callback
+
+  createOnErrorFunc: (command) =>
+    (nodeError) =>
+      @bufferedProcess = null
+      @emitter.emit 'did-not-run', { command: command }
+      @view.showUnableToRunError(command)
+      nodeError.handle()
+
+  onDidNotRun: (callback) =>
+    @emitter.on 'did-not-run', callback
+
+  options: ->
+    cwd: @getCwd()
+    env: @runOptions.mergedEnv(process.env)
+
+  args: (codeContext, extraArgs) ->
+    args = (@runOptions.cmdArgs.concat extraArgs).concat @runOptions.scriptArgs
+    if not @runOptions.cmd? or @runOptions.cmd is ''
+      args = codeContext.shebangCommandArgs().concat args
+

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -4,6 +4,11 @@ module.exports =
 class Runner
   bufferedProcess: null
 
+  # Public: Creates a Runner instance
+  #
+  # * `runOptions` a {ScriptOptions} object instance
+  # * `inputProvider` An {Object} with `write(Readable Stream)` method
+  # * `emitter` Atom's {Emitter} instance. You probably don't need to overwrite it
   constructor: (@runOptions, @inputProvider = null, @emitter = new Emitter) ->
 
   run: (command, extraArgs, codeContext) ->

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -7,11 +7,10 @@ class Runner
   # Public: Creates a Runner instance
   #
   # * `runOptions` a {ScriptOptions} object instance
-  # * `inputProvider` An {Object} with `write(Readable Stream)` method
   # * `emitter` Atom's {Emitter} instance. You probably don't need to overwrite it
-  constructor: (@runOptions, @inputProvider = null, @emitter = new Emitter) ->
+  constructor: (@runOptions, @emitter = new Emitter) ->
 
-  run: (command, extraArgs, codeContext) ->
+  run: (command, extraArgs, codeContext, inputString = null) ->
     @startTime = new Date()
 
     args = @args(codeContext, extraArgs)
@@ -24,8 +23,8 @@ class Runner
       command, args, options, stdout, stderr, exit
     })
 
-    if @inputProvider
-      @inputProvider.write(@bufferedProcess.process.stdin)
+    if inputString
+      @bufferedProcess.process.stdin.write(inputString)
 
     @bufferedProcess.onWillThrowError(@createOnErrorFunc(command))
 

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -14,13 +14,14 @@ class Runner
   run: (command, extraArgs, codeContext) ->
     @startTime = new Date()
 
+    args = @args(codeContext, extraArgs)
+    options = @options()
+    stdout = @stdoutFunc
+    stderr = @stderrFunc
+    exit = @onExit
+
     @bufferedProcess = new BufferedProcess({
-      command,
-      @args(codeContext, extraArgs),
-      @options(),
-      @stdoutFunc,
-      @stderrFunc,
-      @onExit
+      command, args, options, stdout, stderr, exit
     })
 
     if @inputProvider
@@ -31,13 +32,13 @@ class Runner
   stdoutFunc: (output) =>
     @emitter.emit 'did-write-to-stdout', { message: output }
 
-  onDidWriteToStdout: (callback) =>
+  onDidWriteToStdout: (callback) ->
     @emitter.on 'did-write-to-stdout', callback
 
   stderrFunc: (output) =>
     @emitter.emit 'did-write-to-stderr', { message: output }
 
-  onDidWriteToStderr: (callback) =>
+  onDidWriteToStderr: (callback) ->
     @emitter.on 'did-write-to-stderr', callback
 
   destroy: ->
@@ -66,7 +67,7 @@ class Runner
 
     @emitter.emit 'did-exit', { executionTime: executionTime, returnCode: returnCode }
 
-  onDidExit: (callback) =>
+  onDidExit: (callback) ->
     @emitter.on 'did-exit', callback
 
   createOnErrorFunc: (command) =>
@@ -75,7 +76,7 @@ class Runner
       @emitter.emit 'did-not-run', { command: command }
       nodeError.handle()
 
-  onDidNotRun: (callback) =>
+  onDidNotRun: (callback) ->
     @emitter.on 'did-not-run', callback
 
   options: ->

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -1,9 +1,7 @@
 CodeContext = require './code-context'
 grammarMap = require './grammars'
 HeaderView = require './header-view'
-Runner = require './runner'
 ScriptOptionsView = require './script-options-view'
-ViewFormatter = require './view-formatter'
 
 {CompositeDisposable} = require 'atom'
 {View, $$} = require 'atom-space-pen-views'
@@ -30,8 +28,7 @@ class ScriptView extends View
   initialize: (
     serializeState,
     @runOptions,
-    @runner = new Runner(@runOptions),
-    @formatters = [new ViewFormatter(@runner, this)]
+    @runner
   ) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -254,8 +254,8 @@ class ScriptView extends View
     @output.append err
     @stop()
 
-  run: (command, extraArgs, codeContext) ->
-    @runner.run(command, extraArgs, codeContext)
+  run: (command, extraArgs, codeContext, input = null) ->
+    @runner.run(command, extraArgs, codeContext, input)
 
   setHeaderStatus: (status) ->
     @headerView.setStatus status

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -3,6 +3,7 @@ grammarMap = require './grammars'
 HeaderView = require './header-view'
 Runner = require './runner'
 ScriptOptionsView = require './script-options-view'
+ViewFormatter = require './view-formatter'
 
 {CompositeDisposable} = require 'atom'
 {View, $$} = require 'atom-space-pen-views'
@@ -26,7 +27,12 @@ class ScriptView extends View
       @div class: css, outlet: 'script', tabindex: -1, =>
         @div class: 'panel-body padded output', outlet: 'output'
 
-  initialize: (serializeState, @runOptions, @runner = new Runner(@runOptions)) ->
+  initialize: (
+    serializeState,
+    @runOptions,
+    @runner = new Runner(@runOptions),
+    @formatters = [new ViewFormatter(@runner, this)]
+  ) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
       'core:cancel': => @close()
@@ -36,15 +42,6 @@ class ScriptView extends View
       'script:kill-process': => @stop()
       'script:run-by-line-number': => @lineRun()
       'script:run': => @defaultRun()
-
-    @subscriptions.add @runner.onDidWriteToStderr (ev) =>
-      @display 'stderr', ev.message
-    @subscriptions.add @runner.onDidWriteToStdout (ev) =>
-      @display 'stdout', ev.message
-    @subscriptions.add @runner.onDidExit (ev) =>
-      @setHeaderAndShowExecutionTime ev.returnCode, ev.executionTime
-    @subscriptions.add @runner.onDidNotRun (ev) =>
-      @showUnableToRunError ev.command
 
     @ansiFilter = new AnsiFilter
 

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -1,10 +1,12 @@
-grammarMap = require './grammars'
-
-{BufferedProcess, CompositeDisposable} = require 'atom'
-{View, $$} = require 'atom-space-pen-views'
 CodeContext = require './code-context'
+grammarMap = require './grammars'
 HeaderView = require './header-view'
+Runner = require './runner'
 ScriptOptionsView = require './script-options-view'
+
+{CompositeDisposable} = require 'atom'
+{View, $$} = require 'atom-space-pen-views'
+
 AnsiFilter = require 'ansi-to-html'
 stripAnsi = require 'strip-ansi'
 _ = require 'underscore'
@@ -12,7 +14,6 @@ _ = require 'underscore'
 # Runs a portion of a script through an interpreter and displays it line by line
 module.exports =
 class ScriptView extends View
-  @bufferedProcess: null
   @results: ""
 
   @content: ->
@@ -25,7 +26,7 @@ class ScriptView extends View
       @div class: css, outlet: 'script', tabindex: -1, =>
         @div class: 'panel-body padded output', outlet: 'output'
 
-  initialize: (serializeState, @runOptions) ->
+  initialize: (serializeState, @runOptions, @runner = new Runner(@runOptions)) ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
       'core:cancel': => @close()
@@ -36,11 +37,27 @@ class ScriptView extends View
       'script:run-by-line-number': => @lineRun()
       'script:run': => @defaultRun()
 
+    @subscriptions.add @runner.onDidWriteToStderr (ev) =>
+      @display 'stderr', ev.message
+    @subscriptions.add @runner.onDidWriteToStdout (ev) =>
+      @display 'stdout', ev.message
+    @subscriptions.add @runner.onDidExit (ev) =>
+      @setHeaderAndShowExecutionTime ev.returnCode, ev.executionTime
+    @subscriptions.add @runner.onDidNotRun (ev) =>
+      @showUnableToRunError ev.command
+
     @ansiFilter = new AnsiFilter
 
   serialize: ->
 
   updateOptions: (event) -> @runOptions = event.runOptions
+
+  setHeaderAndShowExecutionTime: (returnCode, executionTime) =>
+      @display 'stdout', '[Finished in '+executionTime.toString()+'s]'
+      if returnCode is 0
+        @setHeaderStatus 'stop'
+      else
+        @setHeaderStatus 'err'
 
   getShebang: (editor) ->
     text = editor.getText()
@@ -228,6 +245,14 @@ class ScriptView extends View
         @a href: encodedURI, 'issue on GitHub'
         @text ', or send your own pull request.'
 
+  showUnableToRunError: (command) ->
+    @output.append $$ ->
+      @h1 'Unable to run'
+      @pre _.escape command
+      @h2 'Is it in your PATH?'
+      @pre "PATH: #{_.escape process.env.PATH}"
+
+
   handleError: (err) ->
     # Display error and kill process
     @headerView.title.text 'Error'
@@ -236,62 +261,15 @@ class ScriptView extends View
     @stop()
 
   run: (command, extraArgs, codeContext) ->
-    startTime = new Date()
+    @runner.run(command, extraArgs, codeContext)
 
-    # Default to where the user opened atom
-    options =
-      cwd: @getCwd()
-      env: @runOptions.mergedEnv(process.env)
-    args = (@runOptions.cmdArgs.concat extraArgs).concat @runOptions.scriptArgs
-    if not @runOptions.cmd? or @runOptions.cmd is ''
-      args = codeContext.shebangCommandArgs().concat args
-
-    stdout = (output) => @display 'stdout', output
-    stderr = (output) => @display 'stderr', output
-    exit = (returnCode) =>
-      @bufferedProcess = null
-
-      if (atom.config.get 'script.enableExecTime') is true
-        executionTime = (new Date().getTime() - startTime.getTime()) / 1000
-        @display 'stdout', '[Finished in '+executionTime.toString()+'s]'
-
-      if returnCode is 0
-        @headerView.setStatus 'stop'
-      else
-        @headerView.setStatus 'err'
-      console.log "Exited with #{returnCode}"
-
-    # Run process
-    @bufferedProcess = new BufferedProcess({
-      command, args, options, stdout, stderr, exit
-    })
-
-    @bufferedProcess.onWillThrowError (nodeError) =>
-      @bufferedProcess = null
-      @output.append $$ ->
-        @h1 'Unable to run'
-        @pre _.escape command
-        @h2 'Is it in your PATH?'
-        @pre "PATH: #{_.escape process.env.PATH}"
-      nodeError.handle()
-
-  getCwd: ->
-    cwd = @runOptions.workingDirectory
-
-    workingDirectoryProvided = cwd? and cwd isnt ''
-    paths = atom.project.getPaths()
-    if not workingDirectoryProvided and paths?.length > 0
-      cwd = paths[0]
-
-    cwd
+  setHeaderStatus: (status) ->
+    @headerView.setStatus status
 
   stop: ->
-    # Kill existing process if available
-    if @bufferedProcess?
-      @display 'stdout', '^C'
-      @headerView.setStatus 'kill'
-      @bufferedProcess.kill()
-      @bufferedProcess = null
+    @display 'stdout', '^C'
+    @headerView.setStatus 'kill'
+    @runner.stop()
 
   display: (css, line) ->
     @results += line

--- a/lib/script.coffee
+++ b/lib/script.coffee
@@ -1,7 +1,9 @@
+GrammarUtils = require './grammar-utils'
+Runner = require './runner'
 ScriptView = require './script-view'
 ScriptOptionsView = require './script-options-view'
 ScriptOptions = require './script-options'
-GrammarUtils = require './grammar-utils'
+ViewFormatter = require './view-formatter'
 
 module.exports =
   config:
@@ -23,8 +25,10 @@ module.exports =
 
   activate: (state) ->
     @scriptOptions = new ScriptOptions()
-    @scriptView = new ScriptView state.scriptViewState, @scriptOptions
+    @runner = new Runner(@scriptOptions)
+    @scriptView = new ScriptView state.scriptViewState, @scriptOptions, @runner
     @scriptOptionsView = new ScriptOptionsView @scriptOptions
+    @formatter = new ViewFormatter(@runner, @scriptView)
 
   deactivate: ->
     GrammarUtils.deleteTempFiles()

--- a/lib/view-formatter.coffee
+++ b/lib/view-formatter.coffee
@@ -1,0 +1,17 @@
+{CompositeDisposable} = require 'atom'
+
+module.exports =
+class ViewFormatter
+  constructor: (@runner, @view, @subscriptions = new CompositeDisposable) ->
+    @subscriptions.add @runner.onDidWriteToStderr (ev) =>
+      @view.display 'stderr', ev.message
+    @subscriptions.add @runner.onDidWriteToStdout (ev) =>
+      @view.display 'stdout', ev.message
+    @subscriptions.add @runner.onDidExit (ev) =>
+      @view.setHeaderAndShowExecutionTime ev.returnCode, ev.executionTime
+    @subscriptions.add @runner.onDidNotRun (ev) =>
+      @view.showUnableToRunError ev.command
+
+
+  destroy: ->
+    @subscriptions?.dispose()

--- a/spec/fixtures/ioTest.js
+++ b/spec/fixtures/ioTest.js
@@ -1,0 +1,8 @@
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('readable', function() {
+  var chunk = process.stdin.read();
+   if (chunk !== null) {
+     console.log('TEST: ' + chunk);
+   }
+})

--- a/spec/fixtures/outputTest.js
+++ b/spec/fixtures/outputTest.js
@@ -1,0 +1,1 @@
+console.log('hello')

--- a/spec/fixtures/throw.js
+++ b/spec/fixtures/throw.js
@@ -1,0 +1,1 @@
+throw 'kaboom'

--- a/spec/runner-spec.coffee
+++ b/spec/runner-spec.coffee
@@ -1,0 +1,66 @@
+Runner = require '../lib/runner'
+ScriptOptions = require '../lib/script-options'
+
+describe 'Runner', ->
+  beforeEach ->
+    @command = 'node'
+    @runOptions = new ScriptOptions
+    @runOptions.cmd = @command
+    @runner = new Runner(@runOptions, null)
+
+  afterEach ->
+    @runner.destroy()
+
+  describe 'run', ->
+    it 'with no input', ->
+      runs =>
+        @output = null
+        @runner.onDidWriteToStdout (output) =>
+          @output = output
+        @runner.run(@command, ['./outputTest.js'], {})
+
+      waitsFor =>
+        @output != null
+      , "File should execute", 500
+
+      runs =>
+        expect(@output).toEqual({ message: 'hello\n' })
+
+    it 'with an input string', ->
+      runs =>
+        @output = null
+        @runner.onDidWriteToStdout (output) =>
+          @output = output
+        @runner.run(@command, ['./ioTest.js'], {}, 'hello')
+
+      waitsFor =>
+        @output != null
+      , "File should execute", 500
+
+      runs =>
+        expect(@output).toEqual({ message: 'TEST: hello\n' })
+
+    it 'exits', ->
+      runs =>
+        @exited = false
+        @runner.onDidExit =>
+          @exited = true
+        @runner.run(@command, ['./outputTest.js'], {})
+
+      waitsFor =>
+        @exited
+      , "Should receive exit callback", 500
+
+    it 'notifies about writing to stderr', ->
+      runs =>
+        @failedEvent = null
+        @runner.onDidWriteToStderr (event) =>
+          @failedEvent = event
+        @runner.run(@command, ['./throw.js'], {})
+
+      waitsFor =>
+        @failedEvent
+      , "Should receive failure callback", 500
+
+      runs =>
+        expect(@failedEvent.message).toMatch(/kaboom/)


### PR DESCRIPTION
My company's preparing to run a small and unusual Hackathon and our vision is to have Atom as a default text editor with a few plugins that will help us with hosting it.

We decided to use Atom-Script as a runner, but it lacks some functionality so I decided to do some refactoring so it's implemented easier.

* **Custom input source:** I made it possible to customize an input provider that accepts Node's stdin Stream.
*  **Custom formatting options:** I don't always want to show the output in an Atom view For example for our event we're planning to make a web request with the output and receive feedback about the solution. I believe some people'd also like to write to a file instead to the view. I used the subscription model following the conventions from [this post](http://blog.atom.io/2014/09/16/new-event-subscription-api.html)

Please let me know what you think about this!