### PR TITLE
Add pandoc markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Currently supported grammars are:
   * Objective-C <sup>[*](#asterisk)</sup><sup>[‡](#double-dagger)</sup>
   * Objective-C++ <sup>[*](#asterisk)</sup><sup>[‡](#double-dagger)</sup>
   * OCaml <sup>[*](#asterisk)</sup>
-  * Pandoc Markdown
+  * Pandoc Markdown <sup>[††](#two-daggers)</sup>
   * Perl
   * Perl 6
   * PHP
@@ -76,6 +76,8 @@ You only have to add a few lines in a PR to support another.
 <a name="double-dagger"></a><sup>‡</sup> C, C++, Objective-C, and Objective-C++ are currently only available for Mac OS X (where `process.platform is 'darwin'`). This is possible due to the commands `xcrun clang` and `xcrun clang++`. **NOTE**: Xcode and the Xcode command line tools are required to ensure `xcrun` and the correct compilers on your system.
 
 <a name="hash"></a><sup>#</sup> NCL scripts must end with `exit` command for file based runs
+
+<a name="two-daggers"></a><sup>††</sup> Requires the panzer pandoc wrapper https://github.com/msprev/panzer and the pandoc-flavored-markdown language package in Atom https://atom.io/packages/language-pfm
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Currently supported grammars are:
   * Objective-C <sup>[*](#asterisk)</sup><sup>[‡](#double-dagger)</sup>
   * Objective-C++ <sup>[*](#asterisk)</sup><sup>[‡](#double-dagger)</sup>
   * OCaml <sup>[*](#asterisk)</sup>
+  * Pandoc Markdown
   * Perl
   * Perl 6
   * PHP

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -284,6 +284,11 @@ module.exports =
       command: "ocaml"
       args: (context) -> [context.filepath]
 
+  'Pandoc Markdown':
+    "File Based":
+      command: "panzer"
+      args: (context) -> [context.filepath, "--output=" + context.filepath + ".pdf"]
+
   PHP:
     "Selection Based":
       command: "php"


### PR DESCRIPTION
support for pandoc markdown using panzer wrapper:

https://github.com/msprev/panzer

panzer allows for sets of pandoc arguments to be saved as style presets
and passed to pandoc.

This is a good fit for atom-script is it saves the user having to enter
lots of arguments into the “Configure Script” dialog.

This fills an important gap in the Atom ecosystem. Although there are lots of packages that can preview pandoc output, so far there are none to build a pandoc document. See discussion thread here: https://discuss.atom.io/t/using-atom-for-academic-writing/19222/19