### PR TITLE
Add JavaScript for Automation (JXA) support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently supported grammars are:
   * Haskell
   * Java
   * Javascript
+  * [JavaScript for Automation](https://developer.apple.com/library/mac/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/Introduction.html) (JXA)
   * Julia
   * Kotlin
   * LaTeX (via latexmk)

--- a/examples/jxa.js
+++ b/examples/jxa.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env osascript -l JavaScript
+
+test = Application.currentApplication()
+
+test.includeStandardAdditions = true
+
+test.displayDialog("Hello world")

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -164,6 +164,14 @@ module.exports =
       command: "babel-node"
       args: (context) -> [context.filepath]
 
+  "JavaScript for Automation":
+    "Selection Based":
+      command: "osascript"
+      args: (context)  -> ['-l', 'JavaScript', '-e', context.getCode()]
+    "File Based":
+      command: "osascript"
+      args: (context) -> ['-l', 'JavaScript', context.filepath]
+
   Julia:
     "Selection Based":
       command: "julia"


### PR DESCRIPTION
Support for JXA, introduced in OS X 10.10 Yosemite.

Signed-off-by: Daniel Bayley <daniel.bayley@me.com>