### PR TITLE
Add PostgreSQL support

### DIFF
--- a/examples/hello.sql
+++ b/examples/hello.sql
@@ -1,0 +1,5 @@
+-- "Hello, world!" from SQL (PostgreSQL)
+
+SELECT string_agg(w, ' ') AS welcome
+FROM   (VALUES ('Hello'),
+               ('World')) AS t(w);

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -458,6 +458,14 @@ module.exports =
       command: "fish"
       args: (context) -> [context.filepath]
 
+  "SQL (PostgreSQL)":
+    "Selection Based":
+      command: "psql"
+      args: (context) -> ['-c', context.getCode()]
+    "File Based":
+      command: "psql"
+      args: (context) -> ['-f', context.filepath]
+
   "Standard ML":
     "File Based":
       command: "sml"


### PR DESCRIPTION
- Supports selection-based and file-based invocation of PostgreSQL's interactive command line `psql`.

- Connects as user `$PGUSER` to database `$PGDATABASE`.

  Both default to the operating system's user name and both can be set in the process environment, 
  e.g. in Atom's `init.coffee` script:

      process.env.PGUSER = ⟨username⟩
      process.env.PGDATABASE = ⟨database name⟩