### PR TITLE
Porting ScriptView to use MessagePanelView

### DIFF
--- a/lib/header-view.coffee
+++ b/lib/header-view.coffee
@@ -4,16 +4,9 @@ module.exports =
 class HeaderView extends View
 
   @content: ->
-    @div class: 'panel-heading padded heading header-view', =>
+    @div class: 'header-view', =>
       @span class: 'heading-title', outlet: 'title'
       @span class: 'heading-status', outlet: 'status'
-      @span
-        class: 'heading-close icon-remove-close pull-right'
-        outlet: 'closeButton'
-        click: 'close'
-
-  close: ->
-    atom.commands.dispatch @workspaceView(), 'script:close-view'
 
   setStatus: (status) ->
     @status.removeClass 'icon-alert icon-check icon-hourglass icon-stop'
@@ -22,6 +15,3 @@ class HeaderView extends View
       when 'stop' then @status.addClass 'icon-check'
       when 'kill' then @status.addClass 'icon-stop'
       when 'err' then @status.addClass 'icon-alert'
-
-  workspaceView: ->
-    atom.views.getView(atom.workspace)

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -47,10 +47,18 @@ class ScriptView extends MessagePanelView
     # Get script view ready
     @clear()
 
-  close: ->
+  removePanel: ->
     @stop()
     @detach()
-    super
+    # the 'close' method from MessagePanelView actually destroys the panel
+    ScriptView.__super__.close.apply(this)
+
+  # This is triggered when hitting the 'close' button on the panel
+  # We are not actually closing the panel here since we want to trigger
+  # 'script:close-view' which will eventually remove the panel via 'removePanel'
+  close: ->
+    workspaceView = atom.views.getView(atom.workspace)
+    atom.commands.dispatch workspaceView, 'script:close-view'
 
   stop: ->
     @display 'stdout', '^C'

--- a/lib/script.coffee
+++ b/lib/script.coffee
@@ -51,14 +51,14 @@ module.exports =
 
   deactivate: ->
     @runtime.destroy()
-    @scriptView.close()
+    @scriptView.removePanel()
     @scriptOptionsView.close()
     @subscriptions.dispose()
     GrammarUtils.deleteTempFiles()
 
   closeScriptViewAndStopRunner: ->
     @runtime.stop()
-    @scriptView.close()
+    @scriptView.removePanel()
 
   # Public
   #

--- a/package.json
+++ b/package.json
@@ -316,7 +316,8 @@
     "node-uuid": "~1.4.0",
     "strip-ansi": "^3.0.0",
     "underscore": "~1.5.2",
-    "atom-space-pen-views": "^2.0.3"
+    "atom-space-pen-views": "^2.0.3",
+    "atom-message-panel": "1.2.4"
   },
   "devDependencies": {
     "grunt": "~0.4.5"

--- a/styles/script.less
+++ b/styles/script.less
@@ -5,20 +5,6 @@
 @import "ui-variables";
 
 .header-view {
-  position: fixed;
-  width: 100%;
-  z-index:10;
-  position:relative;
-
-
-  .heading-close {
-    color: @text-color-highlight;
-  }
-
-  .heading-title {
-    padding-left: 6px;
-  }
-
   .heading-status {
     padding-left: 9px;
   }
@@ -41,12 +27,7 @@
 }
 
 .script-view {
-  overflow: scroll;
-  max-height: 300px;
-  height: auto;
-  margin-bottom: 0px;
-
-  .panel-body pre{
+  .panel-body pre {
     background: @tool-panel-background-color;
     color: @text-color;
   }


### PR DESCRIPTION
A pull request for #631.
This allows resizing and minimization of the output panel. 

Unlike what's mentioned in the issue, this commit directly overwrites `ScriptView` with the new functionality. Also, I think I figured out the conditional scrolling bit mentioned in the issue, so it's included as well (see [here](https://github.com/ncreep/atom-script/blob/42c77e733f0eabef242feec1c7c79be9b593ba98/lib/script-view.coffee#L125)).