### PR TITLE
Imporving the `link-paths` function

### DIFF
--- a/lib/link-paths.coffee
+++ b/lib/link-paths.coffee
@@ -1,4 +1,9 @@
-regex = /// (/?(?:[-\w.]+/)*[-\w.]+):(\d+):(\d+) ///g
+regex = ///
+  ((?:\w:)?/?            # Prefix of the path either '/' or 'C:/' (optional)
+  (?:[-\w.]+/)*[-\w.]+)  # The path of the file some/file/path.ext
+  :(\d+)                 # Line number prefixed with a colon
+  (?::(\d+))?            # Column number prefixed with a colon (optional)
+///g
 template = '<a class="-linked-path" data-path="$1" data-line="$2" data-column="$3">$&</a>'
 
 module.exports = linkPaths = (lines) ->
@@ -9,7 +14,8 @@ linkPaths.listen = (parentView) ->
     el = this
     {path, line, column} = el.dataset
     line = Number(line) - 1
-    column = Number(column) - 1
+    # column number is optional
+    column = if column then Number(column) - 1 else 0
 
     atom.workspace.open path, {
       initialLine: line

--- a/spec/link-paths-spec.coffee
+++ b/spec/link-paths-spec.coffee
@@ -10,6 +10,15 @@ describe 'linkPaths', ->
     expect(result).toContain 'data-column="55"'
     expect(result).toContain 'b/c.js:44:55'
 
+  it 'detects file paths with Windows style drive prefix', ->
+    result = linkPaths 'foo() C:/b/c.js:44:55'
+    expect(result).toContain 'data-path="C:/b/c.js"'
+
+  it 'allow ommitting the column number', ->
+    result = linkPaths 'foo() b/c.js:44'
+    expect(result).toContain 'data-line="44"'
+    expect(result).toContain 'data-column=""'
+
   it 'links multiple paths', ->
     multilineResult = linkPaths """
       foo() b/c.js:44:55


### PR DESCRIPTION
Now 'link-paths' should work with Windows style drive prefixes (e.g., C:/).
The column number is optional.