### PR TITLE
Updated Swift language compatibility.

### DIFF
--- a/examples/richard.swift
+++ b/examples/richard.swift
@@ -1,4 +1,16 @@
-// Richard Swift - The Shade (DC Comics)
+#!/usr/bin/swift
 
-var who = "World"
-println("Hello, \(who)!")
+// To use this file as script:
+/*
+ $ chmod +x /path/to/file.swift
+ $ /path/to/file.swift
+ > Hello, World
+*/
+
+import Swift
+
+public func greet(receiver: String) {
+  print("Hello, \(receiver)")
+}
+
+greet("World")

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -489,8 +489,8 @@ module.exports =
 
   Swift:
     "File Based":
-      command: "xcrun"
-      args: (context) -> ['swift', context.filepath]
+      command: "swift"
+      args: (context) -> [context.filepath]
 
   TypeScript:
     "Selection Based":


### PR DESCRIPTION
__Swift__ language is now open source. Command 'swift' is available on Linux-based platforms (after installing Swift compiler) and OS X.

The example code is outdated. `println()` is from __Swift 1.x Standard Library__. It was renamed to `print()` in __Swift 2 Standard Library__.
Updated the code to be compatible with __Swift 2 Standard Library__. 
Also, now __Swift__ example can be executed as a 'script' from command line.
