### PR TITLE
Update grammars.coffee with MagicPython syntax

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -241,6 +241,14 @@ module.exports =
       command: "lua"
       args: (context) -> [context.filepath]
 
+  MagicPython:
+    "Selection Based":
+      command: "python"
+      args: (context)  -> ['-c', context.getCode()]
+    "File Based":
+      command: "python"
+      args: (context) -> [context.filepath]
+
   MoonScript:
     "Selection Based":
       command: "moon"


### PR DESCRIPTION
MagicPython is a very nice, smarter python syntax. 

Fixes #661, #649, #640, #633, which are all the same issue.