### PR TITLE
Fixed Java not running on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently supported grammars are:
   * Go <sup>[*](#asterisk)</sup>
   * Groovy
   * Haskell
-  * Java
+  * Java (Windows users should manually add jdk path (...\jdk1.x.x_xx\bin) to their system environment variables)
   * Javascript
   * [JavaScript for Automation](https://developer.apple.com/library/mac/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/Introduction.html) (JXA)
   * Julia

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently supported grammars are:
   * Go <sup>[*](#asterisk)</sup>
   * Groovy
   * Haskell
-  * Java (Windows users should manually add jdk path (...\jdk1.x.x_xx\bin) to their system environment variables)
+  * Java <sup>[***](#triple-asterisk)</sup>
   * Javascript
   * [JavaScript for Automation](https://developer.apple.com/library/mac/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/Introduction.html) (JXA)
   * Julia
@@ -96,6 +96,8 @@ can be set in the process environment or in Atom's `init.coffee` script:
 `process.env.PGUSER = ⟨username⟩` and `process.env.PGDATABASE = ⟨database name⟩`.
 
 <a name="double-asterisk"></a><sup>\**</sup> The shell used is based on your default `$SHELL` environment variable.
+
+<a name="triple-asterisk"></a><sup>\***</sup> Windows users should manually add jdk path (...\jdk1.x.x_xx\bin) to their system environment variables.
 
 ## Installation
 

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -141,12 +141,20 @@ module.exports =
       args: (context) -> [context.filepath]
 
   Java:
-    "File Based":
-      command: "bash"
-      args: (context) ->
-        className = context.filename.replace /\.java$/, ""
-        args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{className}"]
-        return args
+    if GrammarUtils.OperatingSystem.isWindows()
+      "File Based":
+        command: "cmd"
+        args: (context) ->
+          className = context.filename.replace /\.java$/, ""
+          args = ["/c javac -Xlint #{context.filename} && start cmd /k java #{className}"]
+          return args
+    else
+      "File Based":
+        command: "bash"
+        args: (context) ->
+          className = context.filename.replace /\.java$/, ""
+          args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{className}"]
+          return args
 
   JavaScript:
     "Selection Based":

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -141,20 +141,16 @@ module.exports =
       args: (context) -> [context.filepath]
 
   Java:
-    if GrammarUtils.OperatingSystem.isWindows()
-      "File Based":
-        command: "cmd"
-        args: (context) ->
-          className = context.filename.replace /\.java$/, ""
+    "File Based":
+      command: if GrammarUtils.OperatingSystem.isWindows() then "cmd" else "bash"
+      args: (context) ->
+        className = context.filename.replace /\.java$/, ""
+        args = []
+        if GrammarUtils.OperatingSystem.isWindows()
           args = ["/c javac -Xlint #{context.filename} && start cmd /k java #{className}"]
-          return args
-    else
-      "File Based":
-        command: "bash"
-        args: (context) ->
-          className = context.filename.replace /\.java$/, ""
+        else
           args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{className}"]
-          return args
+        return args
 
   JavaScript:
     "Selection Based":


### PR DESCRIPTION
Replaced bash with cmd on Windows. This fixes issues like this: https://github.com/rgbkrk/atom-script/issues/481.

Windows users still need to manually add jdk path (...\jdk1.x.x_xx\bin) to their system environment variables.