### PR TITLE
Add support for 1C (BSL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Run scripts based on file name, a selection of code, or by line number.
 
 Currently supported grammars are:
 
+  * 1C (BSL)
   * AppleScript
   * Bash <sup>[**](#double-asterisk)</sup>
   * Behat Feature

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -5,6 +5,11 @@ _ = require 'underscore'
 GrammarUtils = require '../lib/grammar-utils'
 
 module.exports =
+  '1C (BSL)':
+    'File Based':
+      command: "oscript"
+      args: (context) -> ['-encoding=utf-8', context.filepath]
+
   AppleScript:
     'Selection Based':
       command: 'osascript'


### PR DESCRIPTION
Hi there!
I'm glad to add support for `1C:Enterprise 8` language http://1c-dn.com/1c_enterprise/what_is_1c_enterprise/

It is a very popular platform with its own DSL for development of business applications in CIS.

You can't run whole app through this runner (`oscript`), but you can run external scripts writen it this language. 

You can find grammar [here](https://atom.io/packages/language-1c-bsl), if you need it