### PR TITLE
Added an option to stop a running process on rerun

### DIFF
--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -43,6 +43,7 @@ class Runtime
   # * "File Based"
   # input (Optional) - {String} that'll be provided to the `stdin` of the new process
   execute: (argType = "Selection Based", input = null) ->
+    @stop() if atom.config.get 'script.stopOnRerun'
     @emitter.emit 'did-execute-start'
 
     codeContext = @codeContextBuilder.buildCodeContext(atom.workspace.getActiveTextEditor(), argType)

--- a/lib/script.coffee
+++ b/lib/script.coffee
@@ -23,6 +23,10 @@ module.exports =
       title: 'Scroll with output'
       type: 'boolean'
       default: true
+    stopOnRerun:
+      title: 'Stop running process on rerun'
+      type: 'boolean'
+      default: false
   scriptView: null
   scriptOptionsView: null
   scriptOptions: null


### PR DESCRIPTION
Possible fix for #619
This should be default behavior IMHO, but people seem to use the ability to run multiple processes at the same time ( #116 ), which is breaking the stop function for all but the last started process - so I made it an option defaulting to the current behavior so people can choose whatever they like.