### PR TITLE
Fix for rustc invocation (fix for issue #422)

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -420,7 +420,7 @@ module.exports =
   Rust:
     "File Based":
       command: "bash"
-      args: (context) -> ['-c', "rustc " + context.filepath + " -o /tmp/rs.out && /tmp/rs.out"]
+      args: (context) -> ['-c', "rustc '#{context.filepath}' -o /tmp/rs.out && /tmp/rs.out"]
 
   Makefile:
     "Selection Based":


### PR DESCRIPTION
After having the same issue as described in #422 did a little debugging, that showed that rustc invocation was missing escaping for context.filepath, this pull request shold fix it (at least fixed it for me).