### PR TITLE
Temp fix to deal with the coffee script grammar

### DIFF
--- a/lib/grammar-utils/coffee-script-compiler.coffee
+++ b/lib/grammar-utils/coffee-script-compiler.coffee
@@ -3,8 +3,11 @@
 {execSync} = require 'child_process'
 
 args = ['-e']
-coffee = execSync 'coffee -h' #which coffee | xargs readlink'
-if coffee.toString().match /--cli/ #-redux
-  args.push '--cli'
+try
+  coffee = execSync 'coffee -h' #which coffee | xargs readlink'
+  if coffee.toString().match /--cli/ #-redux
+    args.push '--cli'
+catch e
+  console.error('unable to find coffee')
 
 exports.args = args


### PR DESCRIPTION
This is an attempt to deal with the failed builds for now as well as any coming release. We shouldn't be synchronously calling out to `coffee` as a user may not have it. At the very least, existence should be checked first.