### PR TITLE
Fix for #600, implementation of #741

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently supported grammars are:
   * C <sup>[*](#asterisk)</sup><sup>[‡](#double-dagger)</sup>
   * C++ <sup>[*](#asterisk)</sup><sup>[‡](#double-dagger)</sup>
   * C# Script <sup>[*](#asterisk)</sup>
+  * Clojure (via Leiningen) <sup>[ϖ](#pi)</sup>
   * Coffeescript
   * CoffeeScript (Literate) <sup>[^](#caret)</sup>
   * Crystal
@@ -88,6 +89,8 @@ You only have to add a few lines in a PR to support another.
 <a name="asterisk"></a><sup>*</sup> Cucumber (Gherkin), D, Go, F#, Literate Haskell, OCaml, PowerShell, and Swift do not support selection based runs
 
 <a name="omega"></a><sup>⍵</sup> Lisp selection based runs are limited to single line
+
+<a name="pi"></a><sup>ϖ</sup> Clojure scripts are executed via [Leiningen](http://leiningen.org/)'s [exec](https://github.com/kumarshantanu/lein-exec) plugin. Both `Leiningen` and `exec` must be installed
 
 <a name="double-dagger"></a><sup>‡</sup> C, C++, Objective-C, and Objective-C++ are currently only available for Mac OS X (where `process.platform is 'darwin'`). This is possible due to the commands `xcrun clang` and `xcrun clang++`. **NOTE**: Xcode and the Xcode command line tools are required to ensure `xcrun` and the correct compilers on your system.
 

--- a/examples/hello.clj
+++ b/examples/hello.clj
@@ -1,0 +1,1 @@
+(println "Hello, Clojure")

--- a/lib/command-context.coffee
+++ b/lib/command-context.coffee
@@ -4,9 +4,11 @@ module.exports =
 class CommandContext
   command: null
   args: []
+  options: {}
 
   @build: (runtime, runOptions, codeContext) ->
     commandContext = new CommandContext
+    commandContext.options = runOptions
 
     try
       if not runOptions.cmd? or runOptions.cmd is ''
@@ -29,3 +31,21 @@ class CommandContext
 
     # Return setup information
     commandContext
+
+  quoteArguments: (args) ->
+    ((if arg.trim().indexOf(' ') == -1 then arg.trim() else "'#{arg}'") for arg in args)
+
+  getRepresentation: ->
+    return '' if !@command or !@args.length
+
+    # command arguments
+    commandArgs = if @options.cmdArgs? then @quoteArguments(@options.cmdArgs).join ' ' else ''
+
+    # script arguments
+    args = if @args.length then @quoteArguments(@args).join ' ' else ''
+    scriptArgs = if @options.scriptArgs? then @quoteArguments(@options.scriptArgs).join ' ' else ''
+
+    @command.trim() +
+      (if commandArgs then ' ' + commandArgs else '') +
+      (if args then ' ' + args else '') +
+      (if scriptArgs then ' ' + scriptArgs else '')

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -51,6 +51,14 @@ module.exports =
       command: "scriptcs"
       args: (context) -> ['-script', context.filepath]
 
+  Clojure:
+    "Selection Based":
+      command: "lein"
+      args: (context)  -> ['exec', '-e', context.getCode()]
+    "File Based":
+      command: "lein"
+      args: (context) -> ['exec', context.filepath]
+
   CoffeeScript:
     "Selection Based":
       command: "coffee"

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -62,7 +62,7 @@ class Runtime
       lineNumber: codeContext.lineNumber
 
     @runner.run(commandContext.command, commandContext.args, codeContext, input)
-    @emitter.emit 'started'
+    @emitter.emit 'started', commandContext
 
   # Public: stops execution of the current fork
   stop: ->

--- a/lib/script-view.coffee
+++ b/lib/script-view.coffee
@@ -18,8 +18,34 @@ class ScriptView extends MessagePanelView
     super(title: @headerView, rawTitle: true, closeMethod: 'destroy')
 
     @addClass('script-view')
+    @addShowInTabIcon()
 
     linkPaths.listen @body
+
+  addShowInTabIcon: ->
+    icon = $$ ->
+      @div
+        class: 'heading-show-in-tab inline-block icon-file-text'
+        style: 'cursor: pointer;'
+        outlet: 'btnShowInTab'
+        title: 'Show output in new tab'
+
+    icon.click @showInTab
+    icon.insertBefore @btnAutoScroll
+
+  showInTab: =>
+    # concat output
+    output = ''
+    output += message.text() for message in @messages
+
+    # represent command context
+    context = ''
+    if @commandContext
+      context = "[Command: #{@commandContext.getRepresentation()}]\n"
+
+    # open new tab and set content to output
+    atom.workspace.open().then (editor) ->
+      editor.setText stripAnsi(context + output)
 
   setHeaderAndShowExecutionTime: (returnCode, executionTime) =>
     if (executionTime?)

--- a/lib/view-runtime-observer.coffee
+++ b/lib/view-runtime-observer.coffee
@@ -7,6 +7,8 @@ class ViewRuntimeObserver
   observe: (runtime) ->
     @subscriptions.add runtime.onStart =>
       @view.resetView()
+    @subscriptions.add runtime.onStarted (ev) =>
+      @view.commandContext = ev
     @subscriptions.add runtime.onStopped =>
       @view.stop()
     @subscriptions.add runtime.onDidWriteToStderr (ev) =>

--- a/package.json
+++ b/package.json
@@ -273,6 +273,7 @@
     "runner",
     "Bash",
     "Behat Feature",
+    "Clojure",
     "Coffeescript",
     "CoffeeScript (Literate)",
     "Cucumber (Gherkin)",


### PR DESCRIPTION
Made a fix for #600, added parsing of quoted arguments. I've tested it in PHP and Python with following arguments:
```
arg1 arg2
arg1=val1 arg2
"foo bar" arg2
"foo bar" "foo bar" arg2
arg1="foo bar"
"foo bar" "another string"
"foo bar" 'another string'
'foo bar' arg2
arg1='foo bar'
'foo bar' 'another string'
```

It would be great if someone could take a look at the commit to see is everything in it's place. Command arguments without quotes (" or ') are handled just like before, so I guess this fix won't affect current use cases and will not present new bugs.

Also, I've implemented #741, attached screencast shows how it works:

![out](https://cloud.githubusercontent.com/assets/235075/12378624/b6f581f4-bd65-11e5-8552-dd468e5472e3.gif)

Also, I've added support for Clojure language (via Leiningen tool and its exec plugin), added info about it in README, that should solve #570 and other clojure issues, if any present.

If everything's fine - I'll ship a patch. Not quite sure why CI is failing - I've performed tests locally - everything was fine. And sorry about the mess of issues in this pull request - I'll separate future pull requests by feature.