### PR TITLE
Fix for #504, selection based and unsaved file

### DIFF
--- a/lib/grammar-utils.coffee
+++ b/lib/grammar-utils.coffee
@@ -53,6 +53,11 @@ module.exports =
   # Returns an {Object} which assists in creating temp files containing R code
   R: require './grammar-utils/R'
 
+  # Public: Get the Perl helper object
+  #
+  # Returns an {Object} which assists in creating temp files containing Perl code
+  Perl: require './grammar-utils/perl'
+
   # Public: Get the PHP helper object
   #
   # Returns an {Object} which assists in creating temp files containing PHP code

--- a/lib/grammar-utils/perl.coffee
+++ b/lib/grammar-utils/perl.coffee
@@ -1,0 +1,10 @@
+
+# Public: GrammarUtils.Perl - a module which assist the creation of Perl temporary files
+module.exports =
+  # Public: Create a temporary file with the provided Perl code
+  #
+  # * `code`    A {String} containing some Perl code
+  #
+  # Returns the {String} filepath of the new file
+  createTempFileWithCode: (code) ->
+    module.parent.exports.createTempFileWithCode(code)

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -351,7 +351,10 @@ module.exports =
   Perl:
     "Selection Based":
       command: "perl"
-      args: (context)  -> ['-e', context.getCode()]
+      args: (context) ->
+        code = context.getCode()
+        file = GrammarUtils.Perl.createTempFileWithCode(code)
+        [file]
     "File Based":
       command: "perl"
       args: (context) -> [context.filepath]


### PR DESCRIPTION
Now executing code from new unsaved files and selections by creating a temporary file instead of using the one line mode (-e) - similar to the solution used for R language.