### PR TITLE
Add ability to fill working directory in grammars.coffee

### DIFF
--- a/lib/command-context.coffee
+++ b/lib/command-context.coffee
@@ -3,6 +3,7 @@ grammarMap = require './grammars'
 module.exports =
 class CommandContext
   command: null
+  workingDirectory: null
   args: []
   options: {}
 
@@ -29,6 +30,12 @@ class CommandContext
       runtime.didNotBuildArgs errorSendByArgs
       return false
 
+    if not runOptions.workingDirectory? or runOptions.workingDirectory is ''
+      # Precondition: lang? and lang of grammarMap
+      commandContext.workingDirectory = grammarMap[codeContext.lang][codeContext.argType].workingDirectory or ''
+    else
+      commandContext.workingDirectory = runOptions.workingDirectory
+    
     # Return setup information
     commandContext
 

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -57,6 +57,9 @@ class Runtime
 
     return unless commandContext
 
+    if commandContext.workingDirectory?
+      executionOptions.workingDirectory = commandContext.workingDirectory
+    
     @emitter.emit 'did-context-create',
       lang: codeContext.lang
       filename: codeContext.filename


### PR DESCRIPTION
This adds a new field to grammars.coffee - workingDirectory.
If this is specified it forwards to childprocess.spawn as cwd.

@rgbkrk please review.

It should help @Luthaf with #744