### PR TITLE
Add parent dir of file, if atom opened with only file.

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -1,4 +1,6 @@
 {Emitter, BufferedProcess} = require 'atom'
+fs = require 'fs'
+path = require 'path'
 
 module.exports =
 class Runner
@@ -50,7 +52,7 @@ class Runner
     workingDirectoryProvided = cwd? and cwd isnt ''
     paths = atom.project.getPaths()
     if not workingDirectoryProvided and paths?.length > 0
-      cwd = paths[0]
+      cwd = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
 
     cwd
 


### PR DESCRIPTION
Fix #833 
/cc @rgbkrk 