### PR TITLE
Add support for built in variables in args collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ clipboard, allowing you to paste it into the editor.
 | Script: Close View         | <kbd>esc</kbd> or <kbd>ctrl-w</kbd> | <kbd>esc</kbd>              | Closes the script view window                                                 |
 | Script: Kill Process       | <kbd>ctrl-c</kbd>                   | <kbd>ctrl-q</kbd>           | Kills the current script process                                              |
 
+### Replacements
+
+The following parameters will be replaced in any entry in `args` (command and program arguments). They should all be enclosed in curly brackets `{}`
+
+  * `{FILE_ACTIVE}` - Full path to the currently active file in Atom. E.g. `/home/rgbkrk/atom-script/lib/script.coffee`
+  * `{FILE_ACTIVE_PATH}` - Full path to the folder where the currently active file is. E.g. `/home/rgbkrk/atom-script/lib`
+  * `{FILE_ACTIVE_NAME}` - Full name and extension of active file. E.g., `script.coffee`
+  * `{FILE_ACTIVE_NAME_BASE}` - Name of active file WITHOUT extension. E.g., `script`
+  * `{PROJECT_PATH}` - Full path to the root of the project. This is normally the path Atom has as root. E.g `/home/rgbkrk/atom-script`
+
+Parameters are compatible with `atom-build` package.
+
 ## Development
 
 Use the atom [contributing guidelines](https://atom.io/docs/latest/contributing).

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -1,4 +1,6 @@
 {Emitter, BufferedProcess} = require 'atom'
+fs = require 'fs'
+path = require 'path'
 
 module.exports =
 class Runner
@@ -83,8 +85,23 @@ class Runner
     cwd: @getCwd()
     env: @scriptOptions.mergedEnv(process.env)
 
+  fillVarsInArg: (arg, codeContext, project_path) ->
+    arg = arg.replace(/{FILE_ACTIVE}/g, codeContext.filepath)
+    arg = arg.replace(/{FILE_ACTIVE_PATH}/g, path.join(codeContext.filepath, '..'))
+    arg = arg.replace(/{FILE_ACTIVE_NAME}/g, codeContext.filename)
+    arg = arg.replace(/{FILE_ACTIVE_NAME_BASE}/g, path.join(codeContext.filename, '..'))
+    arg = arg.replace(/{PROJECT_PATH}/g, project_path)
+    
+    arg
+
   args: (codeContext, extraArgs) ->
     args = (@scriptOptions.cmdArgs.concat extraArgs).concat @scriptOptions.scriptArgs
+    project_path = ''
+    paths = atom.project.getPaths()
+    if paths.length > 0
+      project_path = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
+    args = (@fillVarsInArg arg, codeContext, project_path for arg in args)
+    
     if not @scriptOptions.cmd? or @scriptOptions.cmd is ''
       args = codeContext.shebangCommandArgs().concat args
     args

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -86,11 +86,14 @@ class Runner
     env: @scriptOptions.mergedEnv(process.env)
 
   fillVarsInArg: (arg, codeContext, project_path) ->
-    arg = arg.replace(/{FILE_ACTIVE}/g, codeContext.filepath)
-    arg = arg.replace(/{FILE_ACTIVE_PATH}/g, path.join(codeContext.filepath, '..'))
-    arg = arg.replace(/{FILE_ACTIVE_NAME}/g, codeContext.filename)
-    arg = arg.replace(/{FILE_ACTIVE_NAME_BASE}/g, path.join(codeContext.filename, '..'))
-    arg = arg.replace(/{PROJECT_PATH}/g, project_path)
+    if codeContext.filepath?
+      arg = arg.replace(/{FILE_ACTIVE}/g, codeContext.filepath)
+      arg = arg.replace(/{FILE_ACTIVE_PATH}/g, path.join(codeContext.filepath, '..'))
+    if codeContext.filename?
+      arg = arg.replace(/{FILE_ACTIVE_NAME}/g, codeContext.filename)
+      arg = arg.replace(/{FILE_ACTIVE_NAME_BASE}/g, path.join(codeContext.filename, '..'))
+    if project_path?
+      arg = arg.replace(/{PROJECT_PATH}/g, project_path)
     
     arg
 


### PR DESCRIPTION
Fix #788.

Used variables:
{FILE_ACTIVE} - Full path to the currently active file in Atom. E.g. /home/noseglid/github/atom-build/lib/build.js
{FILE_ACTIVE_PATH} - Full path to the folder where the currently active file is. E.g. /home/noseglid/github/atom-build/lib
{FILE_ACTIVE_NAME} - Full name and extension of active file. E.g., build.js
{FILE_ACTIVE_NAME_BASE} - Name of active file WITHOUT extension. E.g., build
{PROJECT_PATH} - Full path to the root of the project. This is normally the path Atom has as root. E.g /home/noseglid/github/atom-build

Variables is compatible with **build**-package.

ToDo:
* [x] Fix errors :)
* [x] add an instruction to README