### PR TITLE
Check availability of path.

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -52,8 +52,9 @@ class Runner
     workingDirectoryProvided = cwd? and cwd isnt ''
     paths = atom.project.getPaths()
     if not workingDirectoryProvided and paths?.length > 0
-      cwd = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
-
+      try
+        cwd = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
+    
     cwd
 
   stop: ->
@@ -102,7 +103,11 @@ class Runner
     project_path = ''
     paths = atom.project.getPaths()
     if paths.length > 0
-      project_path = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
+      fs.stat(paths[0], (err, stats) ->
+        if !err
+          project_path = if stats.isDirectory() then paths[0] else path.join(paths[0], '..')
+      )
+    
     args = (@fillVarsInArg arg, codeContext, project_path for arg in args)
     
     if not @scriptOptions.cmd? or @scriptOptions.cmd is ''


### PR DESCRIPTION
In some cases (like editing the config.cson) path can lead to something like atom://config
Also make stat() async.

Fix #842 

@rgbkrk can you give a look with async-thing? i've made changes in args() and everyting is ok.
if i made the same changes in getcwd(), tests start fail.

```
failing
run
it with no input
timeout: timed out after 500 msec waiting for File should execute
it with an input string
timeout: timed out after 500 msec waiting for File should execute
it notifies about writing to stderr
Expected 'module.js:341
 throw err;
 ^
 
 Error: Cannot find module 'C:\Users\na_gryzlov\AppData\Local\atom\app-1.5.4\throw.js'
 at Function.Module._resolveFilename (module.js:339:15)
 at Function.Module._load (module.js:290:25)
 at Function.Module.runMain (module.js:447:10)
 at startup (node.js:141:18)
 at node.js:933:3
 ' to match /kaboom/.
Error: Expected 'module.js:341
throw err;
^

Error: Cannot find module 'C:\Users\na_gryzlov\AppData\Local\atom\app-1.5.4\throw.js'
at Function.Module._resolveFilename (module.js:339:15)
at Function.Module._load (module.js:290:25)
at Function.Module.runMain (module.js:447:10)
at startup (node.js:141:18)
at node.js:933:3
' to match /kaboom/.
at file:///D:/git/script/spec/runner-spec.coffee:66:38
it terminates stdin
timeout: timed out after 500 msec waiting for File should execute
```