### PR TITLE
Add ability to change CWD behavior

### DIFF
--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -101,14 +101,14 @@ class Runner
       arg = arg.replace(/{FILE_ACTIVE_NAME_BASE}/g, path.join(codeContext.filename, '..'))
     if project_path?
       arg = arg.replace(/{PROJECT_PATH}/g, project_path)
-
+    
     arg
 
   args: (codeContext, extraArgs) ->
     args = (@scriptOptions.cmdArgs.concat extraArgs).concat @scriptOptions.scriptArgs
     project_path = @getProjectPath or ''
     args = (@fillVarsInArg arg, codeContext, project_path for arg in args)
-
+    
     if not @scriptOptions.cmd? or @scriptOptions.cmd is ''
       args = codeContext.shebangCommandArgs().concat args
     args

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -53,8 +53,9 @@ class Runner
     paths = atom.project.getPaths()
     if not workingDirectoryProvided and paths?.length > 0
       try
-        cwd = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
-    
+        # cwd = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
+        parentDirectory = atom.workspace.getActivePaneItem().buffer.file.getParent().path
+        cwd = if fs.statSync(parentDirectory).isDirectory() then parentDirectory else path.join(paths[0], '..')
     cwd
 
   stop: ->
@@ -95,7 +96,7 @@ class Runner
       arg = arg.replace(/{FILE_ACTIVE_NAME_BASE}/g, path.join(codeContext.filename, '..'))
     if project_path?
       arg = arg.replace(/{PROJECT_PATH}/g, project_path)
-    
+
     arg
 
   args: (codeContext, extraArgs) ->
@@ -107,9 +108,9 @@ class Runner
         if !err
           project_path = if stats.isDirectory() then paths[0] else path.join(paths[0], '..')
       )
-    
+
     args = (@fillVarsInArg arg, codeContext, project_path for arg in args)
-    
+
     if not @scriptOptions.cmd? or @scriptOptions.cmd is ''
       args = codeContext.shebangCommandArgs().concat args
     args

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -50,12 +50,17 @@ class Runner
     cwd = @scriptOptions.workingDirectory
 
     workingDirectoryProvided = cwd? and cwd isnt ''
-    paths = atom.project.getPaths()
-    if not workingDirectoryProvided and paths?.length > 0
+    if not workingDirectoryProvided
       try
-        # cwd = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
-        parentDirectory = atom.workspace.getActivePaneItem().buffer.file.getParent().path
-        cwd = if fs.statSync(parentDirectory).isDirectory() then parentDirectory else path.join(paths[0], '..')
+        switch atom.config.get('script.cwdBehavior')
+          when 'First project directory'
+            paths = atom.project.getPaths()
+            if paths?.length > 0
+              cwd = if fs.statSync(paths[0]).isDirectory() then paths[0] else path.join(paths[0], '..')
+          when 'Project directory of the script'
+            cwd = @getProjectPath()
+          when 'Directory of the script'
+            cwd = atom.workspace.getActivePaneItem().buffer.file.getParent().path
     cwd
 
   stop: ->
@@ -101,16 +106,19 @@ class Runner
 
   args: (codeContext, extraArgs) ->
     args = (@scriptOptions.cmdArgs.concat extraArgs).concat @scriptOptions.scriptArgs
-    project_path = ''
-    paths = atom.project.getPaths()
-    if paths.length > 0
-      fs.stat(paths[0], (err, stats) ->
-        if !err
-          project_path = if stats.isDirectory() then paths[0] else path.join(paths[0], '..')
-      )
-
+    project_path = @getProjectPath or ''
     args = (@fillVarsInArg arg, codeContext, project_path for arg in args)
 
     if not @scriptOptions.cmd? or @scriptOptions.cmd is ''
       args = codeContext.shebangCommandArgs().concat args
     args
+
+  getProjectPath: ->
+    filePath = atom.workspace.getActiveTextEditor().getPath()
+    projectPaths = atom.project.getPaths()
+    for projectPath in projectPaths
+      if filePath.indexOf(projectPath) > -1
+        if fs.statSync(projectPath).isDirectory()
+          return projectPath
+        else
+          return path.join(projectPath, '..')

--- a/lib/runner.coffee
+++ b/lib/runner.coffee
@@ -116,11 +116,9 @@ class Runner
   getProjectPath: ->
     filePath = atom.workspace.getActiveTextEditor().getPath()
     projectPaths = atom.project.getPaths()
-    curProjectPath = ''
     for projectPath in projectPaths
       if filePath.indexOf(projectPath) > -1
-        fs.stat(projectPath, (err, stats) ->
-          if !err
-            curProjectPath = if stats.isDirectory() then projectPath else path.join(projectPath, '..')
-        )
-        return curProjectPath
+        if fs.statSync(projectPath).isDirectory()
+          return projectPath
+        else
+          return path.join(projectPath, '..')

--- a/lib/script.coffee
+++ b/lib/script.coffee
@@ -28,6 +28,23 @@ module.exports =
       title: 'Stop running process on rerun'
       type: 'boolean'
       default: false
+    cwdBehavior:
+      title: 'Default CWD Behavior'
+      description: 'If no Run Options are set, this setting decides how to determine the CWD'
+      type: 'string'
+      default: 'First project directory'
+      enum: [
+        'First project directory'
+        'Project directory of the script'
+        'Directory of the script'
+      ]
+      # For some reason, the text of these options does not show in package settings view
+      # default: 'firstProj'
+      # enum: [
+      #   {value: 'firstProj', description: 'First project directory (if there is one)'}
+      #   {value: 'scriptProj', description: 'Project directory of the script (if there is one)'}
+      #   {value: 'scriptDir', description: 'Directory of the script'}
+      # ]
   scriptView: null
   scriptOptionsView: null
   scriptProfileRunView: null


### PR DESCRIPTION
I've been wanting `script` to "track" with whatever file I have open (may have multiple projects open). Basically, `script`'s default behavior of using the first project directory as CWD was not meeting my needs. I found that there is interest in extending this capability from others as well (ref: #248, #543), so I decided to try my hand at it.

`script` gets a new setting for __'Default CWD Behavior'__ which is an enum with three string options:

1. First project directory - If there is a project directory open it uses the first path
2. Project directory of the script- Uses helper method to determine the project directory for the active editor (if there is one)
3. Directory of the script - This is __my__ desired behavior which is to set CWD to the directory of the active editor

Note: For the config I wanted to use the `enum` options demonstrated in https://atom.io/docs/api/v1.6.0/Config:

> ```
config:
  someSetting:
    type: 'string'
    default: 'foo'
    enum: [
      {value: 'foo', description: 'Foo mode. You want this.'}
      {value: 'bar', description: 'Bar mode. Nobody wants that!'}
    ]
```

but for some reason, when I tried this, the items in the Settings' drop-down menu were blank/invisible (although they worked properly in terms of operation).

__Tested on Windows only!__