### PR TITLE
Fix for C++ not running on Linux

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -45,6 +45,10 @@ module.exports =
       "File Based":
         command: "bash"
         args: (context) -> ['-c', "xcrun clang++ -fcolor-diagnostics -Wc++11-extensions -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
+    else if GrammarUtils.OperatingSystem.isLinux()
+      "File Based":
+        command: "bash"
+        args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
 
   'C# Script File':
     "File Based":


### PR DESCRIPTION
I have noticed a lot of issues around using script to compile and run C++ files. I have written a fix for the problem on Linux using the GNU C++ compiler (g++) and having tested this on my Linux Mint systems, it seems to work.

There is an issue running C++ files on Windows as well, and I'm guessing a similar fix would solve that, but I can't test it on Windows at the moment.