### PR TITLE
Fix grammars to support OCaml

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -346,7 +346,7 @@ module.exports =
         command: "bash"
         args: (context) -> ['-c', "xcrun clang++ -fcolor-diagnostics -Wc++11-extensions -Wall -include stdio.h -include iostream -framework Cocoa " + context.filepath + " -o /tmp/objc-cpp.out && /tmp/objc-cpp.out"]
 
-  ocaml:
+  OCaml:
     "File Based":
       command: "ocaml"
       args: (context) -> [context.filepath]


### PR DESCRIPTION
Removes "Command not configured for OCaml!" issue, since the grammars had a typo that made it not recognize OCaml files.