### PR TITLE
Ignore selection

### DIFF
--- a/lib/code-context-builder.coffee
+++ b/lib/code-context-builder.coffee
@@ -45,10 +45,12 @@ class CodeContextBuilder
     filename = editor.getTitle()
     filepath = editor.getPath()
     selection = editor.getLastSelection()
+    ignoreSelection = atom.config.get 'script.ignoreSelection'
 
-    # If the selection was empty "select" ALL the text
+    # If the selection was empty or if ignore selection is on, then "select" ALL
+    # of the text
     # This allows us to run on new files
-    if selection.isEmpty()
+    if selection.isEmpty() || ignoreSelection
       textSource = editor
     else
       textSource = selection
@@ -77,7 +79,7 @@ class CodeContextBuilder
 
   validateLang: (lang) ->
     valid = true
-    
+
     # Determine if no language is selected.
     if lang is 'Null Grammar' or lang is 'Plain Text'
       @emitter.emit 'did-not-specify-language'

--- a/lib/script.coffee
+++ b/lib/script.coffee
@@ -20,6 +20,10 @@ module.exports =
       title: 'HTML escape console output'
       type: 'boolean'
       default: true
+    ignoreSelection:
+      title: 'Ignore selection (file-based runs only)'
+      type: 'boolean'
+      default: false
     scrollWithOutput:
       title: 'Scroll with output'
       type: 'boolean'


### PR DESCRIPTION
I added a setting to ignore selections so that file based runs will always be performed.  The reason that I added is because I usually select lines of code, comment them out, and then use the run script keyboard shortcut -- only to find that it tried to run the commented code even though I want to run the entire file.  All that this does is remove an extra step in clearing the selection before running.  I thought that this might be a minor convenience for other like-minded users of this package.