### PR TITLE
Java runner not to run in separate console

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -178,7 +178,7 @@ module.exports =
         className = context.filename.replace /\.java$/, ""
         args = []
         if GrammarUtils.OperatingSystem.isWindows()
-          args = ["/c javac -Xlint #{context.filename} && start cmd /k java #{className}"]
+          args = ["/c javac -Xlint #{context.filename} && java #{className}"]
         else
           args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{className}"]
         return args


### PR DESCRIPTION
I believe all runners are supposed to produce output to the script's own console. This is not a case with Java runner, for some reasons for Windows it is implemented in way of opening separate console window, then you actually need to close every time.

This micro pull request change it's behavior and now instead of showing separate console terminal, output is actually where it should be: 
![image](https://cloud.githubusercontent.com/assets/79324/14225215/22eb9c02-f8c3-11e5-8ec3-780159a50c5f.png)
