### PR TITLE
Add support for the Jolie language

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Currently supported grammars are:
   * Java <sup>[***](#triple-asterisk)</sup>
   * Javascript
   * [JavaScript for Automation](https://developer.apple.com/library/mac/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/Introduction.html) (JXA)
+  * Jolie <sup>[*](#asterisk)</sup>
   * Julia
   * Kotlin
   * LaTeX (via latexmk)
@@ -89,7 +90,7 @@ You only have to add a few lines in a PR to support another.
 
 <a name="dagger"></a><sup>†</sup> Erlang uses `erl` for limited selection based runs (see [#70](https://github.com/rgbkrk/atom-script/pull/70))
 
-<a name="asterisk"></a><sup>*</sup> Cucumber (Gherkin), D, Go, F#, Literate Haskell, OCaml, PowerShell, and Swift do not support selection based runs
+<a name="asterisk"></a><sup>*</sup> Cucumber (Gherkin), D, Go, F#, Literate Haskell, Jolie, OCaml, PowerShell, and Swift do not support selection based runs
 
 <a name="omega"></a><sup>⍵</sup> Lisp selection based runs are limited to single line
 

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -207,6 +207,11 @@ module.exports =
       command: "osascript"
       args: (context) -> ['-l', 'JavaScript', context.filepath]
 
+  Jolie:
+    "File Based":
+      command: "jolie"
+      args: (context) -> [context.filepath]
+
   Julia:
     "Selection Based":
       command: "julia"


### PR DESCRIPTION
A (trivial) patch adding support for language-jolie. Supports only entire files, not selections. Also updates README.md. Tested on Linux and MacOS X.