### PR TITLE
Fixes Rust inability to execute on Windows.

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -518,8 +518,15 @@ module.exports =
 
   Rust:
     "File Based":
-      command: "bash"
-      args: (context) -> ['-c', "rustc '#{context.filepath}' -o /tmp/rs.out && /tmp/rs.out"]
+      command: if GrammarUtils.OperatingSystem.isWindows() then "cmd" else "bash"
+      args: (context) ->
+        progname = context.filename.replace /\.rs$/, ""
+        args = []
+        if GrammarUtils.OperatingSystem.isWindows()
+          args = ["/c rustc #{context.filepath} && #{progname}.exe"]
+        else
+          args = ['-c', "rustc '#{context.filepath}' -o /tmp/rs.out && /tmp/rs.out"]
+        return args
 
   Sage:
     "Selection Based":


### PR DESCRIPTION
Allows the execution of .rs files on a Windows machine. 
Tested on Rust version 1.8.0 for Windows.

Before:
![before](https://cloud.githubusercontent.com/assets/2829082/15456329/97d0fd5c-203a-11e6-827f-c3c1dbf3d7eb.PNG)

After:
![after](https://cloud.githubusercontent.com/assets/2829082/15456330/9bbf661a-203a-11e6-9ef0-daa4ecb854f5.PNG)
