### PR TITLE
tweaks to stata

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Currently supported grammars are:
 | Scheme                               | Yes        | Yes             | |
 | Shell Script                         | Yes        | Yes             | The shell used is based on your default `$SHELL` environment variable |
 | Standard ML                          | Yes        |                 | |
-| Stata                                | Yes        | Yes             | Runs through xstata-se |
+| Stata                                | Yes        | Yes             | Runs through Stata. Note stata needs to be added to your system PATH for this to work. `Mac directions <http://www.stata.com/support/faqs/mac/advanced-topics/>`_ . |
 | Swift                                | Yes        |                 | |
 | TypeScript                           | Yes        | Yes             | |
 | Zsh                                  | Yes        | Yes             | The shell used is based on your default `$SHELL` environment variable |

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -604,10 +604,10 @@ module.exports =
 
   Stata:
     "Selection Based":
-      command: "xstata-se"
+      command: "stata"
       args: (context)  -> ['do', context.getCode()]
     "File Based":
-      command: "xstata-se"
+      command: "stata"
       args: (context) -> ['do', context.filepath]
 
   Swift:


### PR DESCRIPTION
Two tweaks -- on installation, realized (a) stata not in path by default (so added to readme) and stata now using `stata` as default command (not `xstata-se`, as on my system). Sorry for late additions -- didn't realize till installed updated version!