### PR TITLE
Enable C++ compiling and running in windows

### DIFF
--- a/lib/grammar-utils/operating-system.coffee
+++ b/lib/grammar-utils/operating-system.coffee
@@ -12,3 +12,6 @@ module.exports =
 
   platform: ->
     process.platform
+  
+  release: ->
+    process.release

--- a/lib/grammar-utils/operating-system.coffee
+++ b/lib/grammar-utils/operating-system.coffee
@@ -14,4 +14,4 @@ module.exports =
     process.platform
   
   release: ->
-    process.release
+    os.release

--- a/lib/grammar-utils/operating-system.coffee
+++ b/lib/grammar-utils/operating-system.coffee
@@ -1,3 +1,5 @@
+os = require 'os'
+
 # Public: GrammarUtils.OperatingSystem - a module which exposes different
 # platform related helper functions.
 module.exports =

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -68,7 +68,7 @@ module.exports =
       "File Based":
         command: "bash"
         args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
-    else if GrammarUtils.OperatingSystem.isWindows() and GrammarUtils.OperatingSystem.release().slice(-1) >= '14399'
+    else if GrammarUtils.OperatingSystem.isWindows() and GrammarUtils.OperatingSystem.release().split(".").slice -1 >= '14399'
       "File Based":
         command: "bash"
         args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '/mnt/" + path.posix.join.apply(path.posix, [].concat([context.filepath.split(path.win32.sep)[0].toLowerCase()], context.filepath.split(path.win32.sep).slice(1))).replace(":", "") + "' -o /tmp/cpp.out && /tmp/cpp.out"]

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -69,7 +69,7 @@ module.exports =
         command: "bash"
         args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
     else if GrammarUtils.OperatingSystem.isWindows() and GrammarUtils.OperatingSystem.release().indexOf("14399") >= 0
-      "File Based:
+      "File Based":
         command: "bash"
         args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
 

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -68,6 +68,10 @@ module.exports =
       "File Based":
         command: "bash"
         args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
+    else if GrammarUtils.OperatingSystem.isWindows() and GrammarUtils.OperatingSystem.release().indexOf("14399") >= 0
+      "File Based:
+        command: "bash"
+        args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
 
   Clojure:
     "Selection Based":

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -68,7 +68,7 @@ module.exports =
       "File Based":
         command: "bash"
         args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
-    else if GrammarUtils.OperatingSystem.isWindows() and GrammarUtils.OperatingSystem.release().indexOf("14399") >= 0
+    else if GrammarUtils.OperatingSystem.isWindows() and GrammarUtils.OperatingSystem.release().slice(-1) >= '14399'
       "File Based":
         command: "bash"
         args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '/mnt/" + path.posix.join.apply(path.posix, [].concat([context.filepath.split(path.win32.sep)[0].toLowerCase()], context.filepath.split(path.win32.sep).slice(1))).replace(":", "") + "' -o /tmp/cpp.out && /tmp/cpp.out"]

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -71,7 +71,7 @@ module.exports =
     else if GrammarUtils.OperatingSystem.isWindows() and GrammarUtils.OperatingSystem.release().indexOf("14399") >= 0
       "File Based":
         command: "bash"
-        args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '" + context.filepath + "' -o /tmp/cpp.out && /tmp/cpp.out"]
+        args: (context) -> ["-c", "g++ -Wall -include stdio.h -include iostream '/mnt/" + path.posix.join.apply(path.posix, [].concat([context.filepath.split(path.win32.sep)[0].toLowerCase()], context.filepath.split(path.win32.sep).slice(1))).replace(":", "") + "' -o /tmp/cpp.out && /tmp/cpp.out"]
 
   Clojure:
     "Selection Based":


### PR DESCRIPTION
Pretty much just copied and pasted. I edited this on GH, so I can't be 100% sure on if it works or not.

But with Microsoft's Insider Preview 14399, they have created a Linux Subsystem for Windows (or LSW). With this, installed, bash is automatically installed, and therefore is available for use from the command line. Better yet, it's available in the exact same way as you would use it on Linux because (as the promo video says) it's "bash running on Linux running on Windows. No Virtual Machine in sight."

Hopefully this will start a new age of not absolutely requiring Visual Studio when developing on Windows?