### PR TITLE
Added processing-java functionality

### DIFF
--- a/examples/bounce/bounce.pde
+++ b/examples/bounce/bounce.pde
@@ -1,0 +1,19 @@
+//Must be contained in a folder with same name for setup and draw to function
+//Other files in this folder are appended on build
+PVector pos;
+PVector vel;
+final float r = 50;
+void setup(){
+  size(300,300);
+  pos = new PVector(random(width-r*2)+r,random(height-r*2)+r);
+  vel = new PVector(random(3,5)*(int)random(0,1)*2-1,random(3,5)*(int)random(0,1)*2-1);
+}
+void draw(){
+  clear();
+  background(255);
+  fill(100,100,100);
+  if(pos.x+vel.x+r > width || pos.x+vel.x-r < 0) vel.x *= -1;
+  if(pos.y+vel.y+r > height || pos.y+vel.y-r < 0) vel.y *= -1;
+  pos.add(vel);
+  ellipse(pos.x,pos.y,r*2,r*2);
+}

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -497,6 +497,11 @@ module.exports =
     "File Based":
       command: "powershell"
       args: (context) -> [context.filepath.replace /\ /g, "` "]
+      
+  Processing:
+    "File Based":
+      command: "bash"
+      args: (context) -> ['-c', 'processing-java --sketch='+context.filepath.replace("/"+context.filename,"")+' --run']
 
   Prolog:
     "File Based":

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -497,11 +497,16 @@ module.exports =
     "File Based":
       command: "powershell"
       args: (context) -> [context.filepath.replace /\ /g, "` "]
-      
+
   Processing:
     "File Based":
-      command: "bash"
-      args: (context) -> ['-c', 'processing-java --sketch='+context.filepath.replace("/"+context.filename,"")+' --run']
+      command: if GrammarUtils.OperatingSystem.isWindows() then "cmd" else "bash"
+      args: (context) ->
+        if GrammarUtils.OperatingSystem.isWindows()
+          return ['/c processing-java --sketch='+context.filepath.replace("\\"+context.filename,"")+' --run']
+        else
+          return ['-c', 'processing-java --sketch='+context.filepath.replace("/"+context.filename,"")+' --run']
+
 
   Prolog:
     "File Based":


### PR DESCRIPTION
Added Processing functionality, this was designed and tested for use with mac-osx 10.11.5 El Capitan using Processing 0241 with up-to-date processing-java command in $PATH. I suspect that this should work on any mac that can run processing, but I have not tested on any other version. Unfortunately, I don't have access to a windows computer nor am I familiar with command prompt, so I was unable to implement windows functionality. 