### PR TITLE
Fix #973 - Uncaught TypeError: args.split is not a function

### DIFF
--- a/lib/script-options-view.coffee
+++ b/lib/script-options-view.coffee
@@ -84,11 +84,11 @@ class ScriptOptionsView extends View
     (replaces['`#match' + (Object.keys(replaces).length + 1) + '`'] = match) for match in matches
 
     # replace strings
-    args = (args.replace(new RegExp(part, 'g'), match) for match, part of replaces)
+    (args = args.replace(new RegExp(part, 'g'), match)) for match, part of replaces
     split = (item for item in args.split ' ' when item isnt '')
 
     replacer = (argument) ->
-      argument = (argument.replace(match, replacement) for match, replacement of replaces)
+      (argument = argument.replace(match, replacement)) for match, replacement of replaces
       argument
 
     # restore strings, strip quotes


### PR DESCRIPTION
The change fixes ability to pass quoted arguments via Configure Script dialog