### PR TITLE
Use ts-node to run typescript files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Currently supported grammars are:
 | Stata                                | Yes        | Yes             | Runs through Stata. Note stata needs to be added to your system PATH for this to work. `Mac directions <http://www.stata.com/support/faqs/mac/advanced-topics/>`_ . |
 | Swift                                | Yes        |                 | |
 | Tcl                                  | Yes        | Yes             | |
-| TypeScript                           | Yes        | Yes             | |
+| TypeScript                           | Yes        | Yes             | Requires `ts-node` https://github.com/TypeStrong/ts-node |
 | Zsh                                  | Yes        | Yes             | The shell used is based on your default `$SHELL` environment variable |
 
 **NOTE**: Some grammars may require you to install [a custom language package](https://atom.io/search?utf8=✓&q=language).

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -824,13 +824,8 @@ module.exports =
 
   TypeScript:
     "Selection Based":
-      command: "bash"
-      args: (context) ->
-        code = context.getCode(true)
-        tmpFile = GrammarUtils.createTempFileWithCode(code, ".ts")
-        jsFile = tmpFile.replace /\.ts$/, ".js"
-        args = ['-c', "tsc --outFile '#{jsFile}' '#{tmpFile}' && node '#{jsFile}'"]
-        return args
+      command: "ts-node"
+      args: (context) -> ['-e', context.getCode()]
     "File Based":
-      command: "bash"
-      args: (context) -> ['-c', "tsc '#{context.filepath}' --outFile /tmp/js.out && node /tmp/js.out"]
+      command: "ts-node"
+      args: (context) -> [context.filepath]


### PR DESCRIPTION
I want to rise the question if we can replace the combination of `tsc` and `node` to run TS scripts with `ts-node`.

The major drawback with tsc/node is that you can't execute scripts with imports.

```ts
import {logger} from './utils'
logger('message')
```

A script like this can't be executed because `atom-script` just compiles and executes the currently active file opened in the editor. `ts-node` would load and transpile the imports automatically.  