### PR TITLE
support for Java packages

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -342,7 +342,7 @@ module.exports =
       command: if GrammarUtils.OperatingSystem.isWindows() then "cmd" else "bash"
       args: (context) ->
         className = context.filename.replace /\.java$/, ""
-        classPackage = (context.filepath.replace atom.project.rootDirectories[0].path + "/", "").replace context.filename, ""
+        classPackage = (context.filepath.replace (GrammarUtils.Nim.projectDir context.filepath) + "/", "").replace context.filename, ""
         args = []
         if GrammarUtils.OperatingSystem.isWindows()
           args = ["/c javac -Xlint #{context.filename} && java #{className}"]

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -342,11 +342,12 @@ module.exports =
       command: if GrammarUtils.OperatingSystem.isWindows() then "cmd" else "bash"
       args: (context) ->
         className = context.filename.replace /\.java$/, ""
+        classPackage = (context.filepath.replace atom.project.rootDirectories[0].path + "/", "").replace context.filename, ""
         args = []
         if GrammarUtils.OperatingSystem.isWindows()
           args = ["/c javac -Xlint #{context.filename} && java #{className}"]
         else
-          args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{className}"]
+          args = ["-c", "javac -cp . -d /tmp '#{context.filepath}' && java -cp /tmp #{classPackage}#{className}"]
         return args
 
   JavaScript:


### PR DESCRIPTION
Added ability to compile and run packaged files in Linux/Mac. Project root must be java source directory.

Folders will be assumed to be package locations so `[atom-projectroot]/myfolder/hello.java` would imply that hello.java is inside the myfolder package. Failing to do so will produce an error. This is typical with standard Java development practices.