### PR TITLE
Implemented dummy runner for generic SQL and added a short how-to to the SQL example.

### DIFF
--- a/examples/hello.sql
+++ b/examples/hello.sql
@@ -1,3 +1,15 @@
+-- To configure a SQL runner, use the following steps:
+--
+-- 1. Run "Script: Run Options" in Atom.
+-- 2. Create a run profile that contains the following lines
+--     For PostgreSQL:
+--         Command: psql
+--         Command Arguments: -h host -p port -d database -U user -q -f {FILE_ACTIVE}
+--     For MySQL:
+--         Command: mysql
+--         Command Arguments: --host=host --user=user --password=password database < {FILE_ACTIVE}
+-- 3. Use "Script: Run With Profile" and select this profile to run the active SQL file.
+
 -- "Hello, world!" from SQL (PostgreSQL)
 
 SELECT string_agg(w, ' ') AS welcome

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -785,6 +785,14 @@ module.exports =
       command: "fish"
       args: (context) -> [context.filepath]
 
+  "SQL":
+    "Selection Based":
+      command: "echo"
+      args: (context) -> ['SQL requires setting \'Script: Run Options\' directly. See https://github.com/rgbkrk/atom-script/tree/master/examples/hello.sql for further information.']
+    "File Based":
+      command: "echo"
+      args: (context) -> ['SQL requires setting \'Script: Run Options\' directly. See https://github.com/rgbkrk/atom-script/tree/master/examples/hello.sql for further information.']      
+
   "SQL (PostgreSQL)":
     "Selection Based":
       command: "psql"


### PR DESCRIPTION
This is a tiny pull request containing only 
* a dummy runner for SQL that provides some information and
* some added lines of "how to configure generic SQL runners" in the example "hello.sql".

This PR originates from [Issue 115 ](https://github.com/rgbkrk/atom-script/issues/115). Steps to test/reproduce can be found either in the Issue 115 thread or in examples/hello.sql.