### PR TITLE
Add support for Ren'py project launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Currently supported grammars are:
 | Racket                               | Yes        | Yes             | |
 | [RANT](https://github.com/TheBerkin/Rant) | Yes        | Yes             | |
 | Reason                               | Yes        | Yes             | |
+| Ren'Py                               | Yes        | No              | Requires `renpy` to be in path. Runs project at root of current file.|
 | RSpec                                | Yes        | Yes             | |
 | Ruby                                 | Yes        | Yes             | |
 | Ruby on Rails                        | Yes        | Yes             | |

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -700,7 +700,7 @@ module.exports =
   "Ren'Py":
     "File Based":
       command: "renpy"
-      args: (context) -> [context.filepath.substr(0, context.filepath.indexOf("/game"))]
+      args: (context) -> [context.filepath.substr(0, context.filepath.lastIndexOf("/game"))]
 
   RSpec:
     "Selection Based":

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -700,7 +700,7 @@ module.exports =
   "Ren'Py":
     "File Based":
       command: "renpy"
-      args: (context) -> [context.filepath.substr(0, context.filepath.lastIndexOf("game"))]
+      args: (context) -> [context.filepath.substr(0, context.filepath.indexOf("/game"))]
 
   RSpec:
     "Selection Based":

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -700,7 +700,7 @@ module.exports =
   "Ren'Py":
     "File Based":
       command: "renpy"
-      args: (context) -> [context.filepath.substr(0, context.filepath.lastIndexOf("/"))]
+      args: (context) -> [context.filepath.substr(0, context.filepath.lastIndexOf("game"))]
 
   RSpec:
     "Selection Based":

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -696,6 +696,11 @@ module.exports =
         else
           args = ['-c', "rebuild '#{progname}.native' && '#{progname}.native'"]
         return args
+      
+  "Ren'Py":
+    "File Based":
+      command: "renpy"
+      args: (context) -> [context.filepath.substr(0, context.filepath.lastIndexOf("/"))]
 
   RSpec:
     "Selection Based":


### PR DESCRIPTION
When in an .rpy file, command-I will launch the current project through the Ren'Py cli. Requires renpy binary to be in path. Selection based does not apply, as the project must be launched as a whole.