### PR TITLE
Modularization and correct retrieval of java class

### DIFF
--- a/lib/grammar-utils.coffee
+++ b/lib/grammar-utils.coffee
@@ -38,6 +38,11 @@ module.exports =
     catch error
       throw ("Error while deleting temporary files (#{error})")
 
+  # Public: Get the Java helper object
+  #
+  # Returns an {Object} which assists in preparing java + javac statements
+  Java: require './grammar-utils/java'
+
   # Public: Get the Lisp helper object
   #
   # Returns an {Object} which assists in splitting Lisp statements.

--- a/lib/grammar-utils/java.coffee
+++ b/lib/grammar-utils/java.coffee
@@ -1,0 +1,38 @@
+# Java script preparation functions
+os = require 'os'
+path = require 'path'
+
+module.exports =
+  # Public: Get atom temp file directory
+  #
+  # Returns {String} containing atom temp file directory
+  tempFilesDir: path.join(os.tmpdir())
+
+  # Public: Get class name of file in context
+  #
+  # * `filePath`  {String} containing file path
+  #
+  # Returns {String} containing class name of file
+  getClassName: (context) ->
+    context.filename.replace /\.java$/, ""
+
+  # Public: Get project path of context
+  #
+  # * `context`  {Object} containing current context
+  #
+  # Returns {String} containing the matching project path
+  getProjectPath: (context) ->
+    projectPaths = atom.project.getPaths()
+    for projectPath in projectPaths
+      if context.filepath.includes(projectPath)
+        projectPath
+
+  # Public: Get package of file in context
+  #
+  # * `context`  {Object} containing current context
+  #
+  # Returns {String} containing class of contextual file
+  getClassPackage: (context) ->
+    projectPath = module.exports.getProjectPath context
+    projectRemoved = (context.filepath.replace projectPath + "/", "")
+    projectRemoved.replace "/" + context.filename, ""

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -341,13 +341,14 @@ module.exports =
     "File Based":
       command: if GrammarUtils.OperatingSystem.isWindows() then "cmd" else "bash"
       args: (context) ->
-        className = context.filename.replace /\.java$/, ""
-        classPackage = (context.filepath.replace (GrammarUtils.Nim.projectDir context.filepath) + "/", "").replace context.filename, ""
-        args = []
+        tmpFolder = GrammarUtils.Java.tempFilesDir
+        className = GrammarUtils.Java.getClassName context
+        classPackage = GrammarUtils.Java.getClassPackage context
+
         if GrammarUtils.OperatingSystem.isWindows()
           args = ["/c javac -Xlint #{context.filename} && java #{className}"]
         else
-          args = ["-c", "javac -cp . -d /tmp '#{context.filepath}' && java -cp /tmp #{classPackage}#{className}"]
+          args = ["-c", "javac -cp . -d '#{tmpFolder}' '#{context.filepath}' && java -cp /tmp #{classPackage}.#{className}"]
         return args
 
   JavaScript:


### PR DESCRIPTION
Package support is now working again (solely on bash supported operating systems as of present). See #1118. 

**To note:** 

- Build files are not deleted following execution
- _getProjectPath_ in `lib/grammar-utils/java.coffee` may add redundancy (use runner instead?)