### PR TITLE
Added support to LAMMPS script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Currently supported grammars are:
 | Jolie                                | Yes        |                 | |
 | Julia                                | Yes        | Yes             | |
 | Kotlin                               | Yes        | Yes             | |
+| LAMMPS                               | Yes        |                 | Only available on Linux and macOS. Requires 'lammps' to be in path. |
 | LaTeX (via latexmk)                  | Yes        |                 | |
 | LilyPond                             | Yes        |                 | |
 | Lisp (via SBCL)                      | Yes        | Yes             | Selection based runs are limited to single line |

--- a/examples/hello.lmp
+++ b/examples/hello.lmp
@@ -1,0 +1,3 @@
+variable w string World
+
+print "Hello $w!"

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -394,6 +394,11 @@ module.exports =
         args = ['-c', "kotlinc #{context.filepath} -include-runtime -d /tmp/#{jarName} && java -jar /tmp/#{jarName}"]
         return args
 
+  LAMMPS:
+    "File Based":
+        command: "lammps"
+        args: (context) -> ['-log', 'none', '-in', context.filepath]
+
   LaTeX:
     "File Based":
       command: "latexmk"

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -395,7 +395,8 @@ module.exports =
         return args
 
   LAMMPS:
-    "File Based":
+    if GrammarUtils.OperatingSystem.isDarwin() || GrammarUtils.OperatingSystem.isLinux()
+      "File Based":
         command: "lammps"
         args: (context) -> ['-log', 'none', '-in', context.filepath]
 

--- a/package.json
+++ b/package.json
@@ -273,6 +273,10 @@
     {
       "name": "A Manning",
       "email": "449a6a9b@opayq.com"
+    },
+    {
+      "name": "Bruno Durán",
+      "email": "bruno.duran.rey@gmail.com"
     }
   ],
   "repository": "https://github.com/rgbkrk/atom-script",
@@ -311,7 +315,8 @@
     "Swift",
     "run",
     "Applescript",
-    "code"
+    "code",
+    "LAMMPS"
   ],
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
To try it you need the [language-lammps](https://atom.io/packages/language-lammps) package in Atom and [LAMMPS](http://lammps.sandia.gov) installed in your computer. If you have a mac you can install it with:

```sh
brew tap homebrew/science
brew install lammps 
```