### PR TITLE
Fix: _this2.find(...).forEach is not a function

### DIFF
--- a/lib/script-options-view.js
+++ b/lib/script-options-view.js
@@ -2,6 +2,7 @@
 
 import { CompositeDisposable, Emitter } from 'atom';
 import { View } from 'atom-space-pen-views';
+import _ from 'underscore';
 import ScriptInputView from './script-input-view';
 
 export default class ScriptOptionsView extends View {
@@ -157,8 +158,8 @@ export default class ScriptOptionsView extends View {
     const inputView = new ScriptInputView({ caption: 'Enter profile name:' });
     inputView.onCancel(() => this.show());
     inputView.onConfirm((profileName) => {
-      if (!profileName) { return; }
-      this.find('atom-text-editor').forEach((editor) => {
+      if (!profileName) return;
+      _.forEach(this.find('atom-text-editor'), (editor) => {
         editor.getModel().setText('');
       });
 


### PR DESCRIPTION
Use `_.forEach` since `this.find('atom-text-editor')` returns a object.

Fixes #1182 