### PR TITLE
Java package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Currently supported grammars are:
 | IcedCoffeeScript                     | Yes        | Yes             | |
 | Inno Setup                           | Yes        |                 | Requires the path of `ISCC.exe` in your system environment variables |
 | [ioLanguage](http://iolanguage.org/) | Yes        | Yes             | |
-| Java                                 | Yes        |                 | Windows users should manually add jdk path (...\jdk1.x.x_xx\bin) to their system environment variables |
+| Java                                 | Yes        |                 | Windows users should manually add jdk path (...\jdk1.x.x_xx\bin) to their system environment variables. Project directory should be the source directory; subfolders imply packaging. |
 | Javascript                           | Yes        | Yes             | |
 | [JavaScript for Automation](https://developer.apple.com/library/mac/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/Introduction.html) (JXA)            | Yes        | Yes             | |
 | Jolie                                | Yes        |                 | |

--- a/lib/grammar-utils/java.js
+++ b/lib/grammar-utils/java.js
@@ -44,6 +44,6 @@ export default {
       return '';
     }
 
-    return '${filenameRemoved}.';
+    return `${filenameRemoved}.`;
   },
 };

--- a/lib/grammar-utils/java.js
+++ b/lib/grammar-utils/java.js
@@ -40,10 +40,10 @@ export default {
     const filenameRemoved = projectRemoved.replace(`/${context.filename}`, '');
 
     // File is in root of src directory - no package
-    if(filenameRemoved == projectRemoved){
-      return "";
+    if (filenameRemoved === projectRemoved) {
+      return '';
     }
 
-    return filenameRemoved + "."
+    return '${filenameRemoved}.';
   },
 };

--- a/lib/grammar-utils/java.js
+++ b/lib/grammar-utils/java.js
@@ -37,6 +37,13 @@ export default {
   getClassPackage(context) {
     const projectPath = module.exports.getProjectPath(context);
     const projectRemoved = (context.filepath.replace(`${projectPath}/`, ''));
-    return projectRemoved.replace(`/${context.filename}`, '');
+    const filenameRemoved = projectRemoved.replace(`/${context.filename}`, '');
+
+    // File is in root of src directory - no package
+    if(filenameRemoved == projectRemoved){
+      return "";
+    }
+
+    return filenameRemoved + "."
   },
 };

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -344,12 +344,13 @@ module.exports =
       args: (context) ->
         className = GrammarUtils.Java.getClassName context
         classPackages = GrammarUtils.Java.getClassPackage context
+        sourcePath = GrammarUtils.Java.getProjectPath context
 
         args = []
         if GrammarUtils.OperatingSystem.isWindows()
           args = ["/c javac -Xlint #{context.filename} && java #{className}"]
         else
-          args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{classPackages}#{className}"]
+          args = ['-c', "javac -sourcepath #{sourcePath} -d /tmp '#{context.filepath}' && java -cp /tmp #{classPackages}#{className}"]
 
         return args
 

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -342,12 +342,15 @@ module.exports =
     "File Based":
       command: if GrammarUtils.OperatingSystem.isWindows() then "cmd" else "bash"
       args: (context) ->
-        className = context.filename.replace /\.java$/, ""
+        className = GrammarUtils.Java.getClassName context
+        classPackages = GrammarUtils.Java.getClassPackage context
+
         args = []
         if GrammarUtils.OperatingSystem.isWindows()
           args = ["/c javac -Xlint #{context.filename} && java #{className}"]
         else
-          args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{className}"]
+          args = ['-c', "javac -d /tmp '#{context.filepath}' && java -cp /tmp #{classPackages}#{className}"]
+
         return args
 
   JavaScript:


### PR DESCRIPTION
I finally got around to adding package support for Java programs. For now, this support is explicitly on bash supported systems (macOS and Linux) and was developed on Linux (Fedora 25). It's probably best not to merge until Windows support is implemented but I would like to get the implementation tested in its current state by other contributors.

**Usage Changes**
Because packages are determined based on folder structure, non-packaged files will fail to run unless they're located in the root of the project directory. This also means that opening files independently without adding a project folder will result in a failing build. These traits follow that of typical Java development suites such as Intellij IDEA and Eclipse.

**Testing**
I wasn't 100% sure how to implement tests of files and directory structures inside the spec so I've [provided a repository](https://github.com/andyrichardson/Atom-Script-Java-Tests) with a number of tests. To make use of them, clone the repository, add the repository directory to Atom and run atom script on each Java file. All should compile and run successfully with the exception of the program inside the _Error_ folder.
