### PR TITLE
add support for Turing

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -856,6 +856,11 @@ module.exports =
       command: "tclsh"
       args: (context) -> [context.filepath]
 
+  Turing:
+    "File Based":
+      command: "turing"
+      args: (context) -> ['-run', context.filepath]
+
   TypeScript:
     "Selection Based":
       command: "ts-node"


### PR DESCRIPTION
Allow to run Turing files with atom-script.

However, you will need [Open Turing](https://github.com/Open-Turing-Project/OpenTuring), 
and you need to add it to PATH.