### PR TITLE
Downgrade/pin atom-message-panel@1.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
   },
   "dependencies": {
     "ansi-to-html": "^0.4.2",
-    "atom-message-panel": "^1.2.7",
+    "atom-message-panel": "1.2.7",
     "atom-space-pen-views": "^2.0.3",
     "uuid": "^3.0.1",
     "strip-ansi": "^3.0.0",


### PR DESCRIPTION
It looks like `atom-message-panel` changed some internal functions which breaks our usage.

For now this fixes #1222 