### PR TITLE
use Bootstrap classes

### DIFF
--- a/lib/script-options-view.js
+++ b/lib/script-options-view.js
@@ -9,35 +9,37 @@ export default class ScriptOptionsView extends View {
 
   static content() {
     this.div({ class: 'options-view' }, () => {
-      this.div({ class: 'panel-heading' }, 'Configure Run Options');
-      this.table(() => {
-        this.tr(() => {
-          this.td({ class: 'first' }, () => this.label('Current Working Directory:'));
-          this.td({ class: 'second' }, () => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputCwd' }));
-        });
-        this.tr(() => {
-          this.td(() => this.label('Command'));
-          this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputCommand' }));
-        });
-        this.tr(() => {
-          this.td(() => this.label('Command Arguments:'));
-          this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputCommandArgs' }));
-        });
-        this.tr(() => {
-          this.td(() => this.label('Program Arguments:'));
-          this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputScriptArgs' }));
-        });
-        this.tr(() => {
-          this.td(() => this.label('Environment Variables:'));
-          this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputEnv' }));
+      this.h4({ class: 'modal-header' }, 'Configure Run Options');
+      this.div({ class: 'modal-body'}, () => {
+        this.table(() => {
+          this.tr(() => {
+            this.td({ class: 'first' }, () => this.label('Current Working Directory:'));
+            this.td({ class: 'second' }, () => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputCwd' }));
+          });
+          this.tr(() => {
+            this.td(() => this.label('Command'));
+            this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputCommand' }));
+          });
+          this.tr(() => {
+            this.td(() => this.label('Command Arguments:'));
+            this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputCommandArgs' }));
+          });
+          this.tr(() => {
+            this.td(() => this.label('Program Arguments:'));
+            this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputScriptArgs' }));
+          });
+          this.tr(() => {
+            this.td(() => this.label('Environment Variables:'));
+            this.td(() => this.tag('atom-text-editor', { mini: '', class: 'editor mini', outlet: 'inputEnv' }));
+          });
         });
       });
-      this.div({ class: 'block buttons' }, () => {
+      this.div({ class: 'modal-footer' }, () => {
         const css = 'btn inline-block-tight';
         this.button({ class: `btn ${css} cancel`, outlet: 'buttonCancel', click: 'close' }, () =>
           this.span({ class: 'icon icon-x' }, 'Cancel'),
         );
-        this.span({ class: 'right-buttons' }, () => {
+        this.span({ class: 'pull-right' }, () => {
           this.button({ class: `btn ${css} save-profile`, outlet: 'buttonSaveProfile', click: 'saveProfile' }, () =>
             this.span({ class: 'icon icon-file-text' }, 'Save as profile'),
           );


### PR DESCRIPTION
Today, I have used *Script: Run Options* for the very first time and noticed this:

![screen shot 2017-03-16 at 09 57 18](https://cloud.githubusercontent.com/assets/1504938/23988866/6ac97308-0a30-11e7-97ca-19edd59ef723.png)

I fixed this by using the default Bootstrap classes for modals (Atom uses Bootstrap to style its components):

![screen shot 2017-03-16 at 10 13 42](https://cloud.githubusercontent.com/assets/1504938/23988963/d4968410-0a30-11e7-9dfc-0dace3db01f5.png)

(I just noticed: it still needs the separators between footer and body)

If you agree with these changes, I will continue to style the other views so we can rid of some of the classes in the `script` style-sheets.