### PR TITLE
Fixed forgotten space

### DIFF
--- a/lib/script-options-view.js
+++ b/lib/script-options-view.js
@@ -10,7 +10,7 @@ export default class ScriptOptionsView extends View {
   static content() {
     this.div({ class: 'options-view' }, () => {
       this.h4({ class: 'modal-header' }, 'Configure Run Options');
-      this.div({ class: 'modal-body'}, () => {
+      this.div({ class: 'modal-body' }, () => {
         this.table(() => {
           this.tr(() => {
             this.td({ class: 'first' }, () => this.label('Current Working Directory:'));


### PR DESCRIPTION
I simply added a space. It seemed to have been forgotten, but appears to be the only error making the Travis CI build fail. The Travis CI build on this fork with only that one change works ([https://travis-ci.org/thepeanutman98/atom-script](url) [![Build Status](http://img.shields.io/travis/thepeanutman98/atom-script.svg?style=flat)](https://travis-ci.org/thepeanutman98/atom-script)).