### PR TITLE
Add support for Bash Automated Test System (Bats)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently supported grammars are:
 | AppleScript                          | Yes        | Yes             | |
 | Babel ES6 JS                         | Yes        | Yes             | |
 | Bash                                 | Yes        | Yes             | The shell used is based on your default `$SHELL` environment variable |
+| Bash Automated Test System (Bats)    | Yes        | Yes             | |
 | Batch                                | Yes        |                 | |
 | Behat Feature                        | Yes        |                 | |
 | BuckleScript                         | Yes        | Yes             | |

--- a/examples/math.bats
+++ b/examples/math.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+@test "addition using bc" {
+  result="$(echo 2+2 | bc)"
+  [ "$result" -eq 4 ]
+}
+
+@test "addition using dc" {
+  result="$(echo 2 2+p | dc)"
+  [ "$result" -eq 4 ]
+}

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -44,6 +44,17 @@ module.exports =
       command: "babel-node"
       args: (context) -> [context.filepath]
 
+  'Bash Automated Test System (Bats)':
+    "File Based":
+      command: "bats"
+      args: (context) -> [context.filepath]
+    "Selection Based":
+      command: 'bats'
+      args: (context) ->
+        code = context.getCode(true)
+        tmpFile = GrammarUtils.createTempFileWithCode(code)
+        [tmpFile]
+
   Batch:
     "File Based":
       command: "cmd.exe"
@@ -168,7 +179,7 @@ module.exports =
     'File Based':
       command: 'coffee'
       args: (context) -> [context.filepath]
-      
+
   "Common Lisp":
     "File Based":
       command: "clisp"


### PR DESCRIPTION
Add support for [bats](https://github.com/sstephenson/bats). Requires `bats` to be installed in the `PATH`. 