### PR TITLE
Handle 'JavaScript with JSX' grammar with node

### DIFF
--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -378,6 +378,14 @@ module.exports =
       command: "node"
       args: (context) -> [context.filepath]
 
+  'JavaScript with JSX':
+    "Selection Based":
+      command: "node"
+      args: (context)  -> ['-e', context.getCode()]
+    "File Based":
+      command: "node"
+      args: (context) -> [context.filepath]
+
   "JavaScript for Automation (JXA)":
     "Selection Based":
       command: "osascript"


### PR DESCRIPTION
This popular [JSX grammar](https://atom.io/packages/language-javascript-jsx) overloads `.js` files into `JavaScript with JSX`, which causes `atom-script` to throw a "Missing profile" error, even for files without any JSX.

This PR fixes that.

Closes https://github.com/rgbkrk/atom-script/issues/1046 https://github.com/rgbkrk/atom-script/issues/1197 and https://github.com/rgbkrk/atom-script/issues/1250.