### PR TITLE
Specify CWD abbreviation before first use

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -40,7 +40,7 @@ export default {
       default: false,
     },
     cwdBehavior: {
-      title: 'Default CWD Behavior',
+      title: 'Default Current Working Directory (CWD) Behavior',
       description: 'If no Run Options are set, this setting decides how to determine the CWD',
       type: 'string',
       default: 'First project directory',


### PR DESCRIPTION
Specify current working directory abbreviation before first use in package settings display.

Although I'm suggesting the common style of handling this, alternative forms could also work to clarify the abbreviation.