### PR TITLE
Add both path separators support for Windows paths

### DIFF
--- a/lib/link-paths.js
+++ b/lib/link-paths.js
@@ -1,16 +1,54 @@
 'use babel';
 
 /* eslint-disable no-multi-str, prefer-const, func-names */
+
+let fs = require('fs');
+
 let linkPaths;
-const regex = new RegExp('((?:\\w:)?/?(?:[-\\w.]+/)*[-\\w.]+):(\\d+)(?::(\\d+))?', 'g');
-// ((?:\w:)?/?            # Prefix of the path either '/' or 'C:/' (optional)
-// (?:[-\w.]+/)*[-\w.]+)  # The path of the file some/file/path.ext
-// :(\d+)                 # Line number prefixed with a colon
-// (?::(\d+))?            # Column number prefixed with a colon (optional)
 
-const template = '<a class="-linked-path" data-path="$1" data-line="$2" data-column="$3">$&</a>';
+const regex = new RegExp('((?:\\w:)?[/\\\\]?' +
+                         '(?:[-\\w.]+[/\\\\])*[-\\w.]+\\.[\\w]+)' +
+                         '(?:(?:.*line |:)(\\d+))?' +
+                         '(?::(\\d+))?', 'g')
+// ((?:\\w:)?[/\\\\]?                     # Prefix of the path either '/' or 'C:/' (optional)
+// (?:[-\\w.]+[/\\\\])*[-\\w.]+\\.[\\w]+) # The path of the file some/file/path.ext
+// (?:(?:.*line |:)(\\d+))?               # Line number prefixed with a colon (optional)
+// (?::(\d+))?                            # Column number prefixed with a colon (optional)
 
-export default linkPaths = lines => lines.replace(regex, template);
+const makeLink = (text, path, line, col) => `<a class="-linked-path" 
+data-path="${path}" data-line="${line}" data-column="${col}">${text}</a>`
+
+let replaceLinks = (text, path, line, col) => {
+  if (typeof line === 'undefined') {
+    line = '';
+  }
+
+  if (typeof col === 'undefined') {
+    col = '';
+  }
+
+  switch (atom.config.get('script.checkFiles')) {
+    case 'Correct file path with extension + line number':
+      if (line === '') {
+        break;
+      } else {
+        return makeLink(text, path, line, col)
+      }
+    case 'Correct file path with extension + check file existance':
+      if (!fs.existsSync(path)) {
+        break;
+      } else {
+        return makeLink(text, path, line, col)
+      }
+    default:
+    case 'Correct file path with extension':
+      return makeLink(text, path, line, col)
+  }
+
+  return text;
+};
+
+export default linkPaths = lines => lines.replace(regex, replaceLinks);
 
 linkPaths.listen = parentView =>
   parentView.on('click', '.-linked-path', function () {

--- a/lib/script.js
+++ b/lib/script.js
@@ -39,6 +39,16 @@ export default {
       type: 'boolean',
       default: false,
     },
+    checkFiles: {
+      title: 'Error stack trace links detection',
+      type: 'string',
+      default: 'Correct file path with extension + line number',
+      enum: [
+        'Correct file path with extension',
+        'Correct file path with extension + line number',
+        'Correct file path with extension + check file existance'
+      ]
+    },
     cwdBehavior: {
       title: 'Default Current Working Directory (CWD) Behavior',
       description: 'If no Run Options are set, this setting decides how to determine the CWD',

--- a/spec/link-paths-spec.js
+++ b/spec/link-paths-spec.js
@@ -14,8 +14,8 @@ describe('linkPaths', () => {
   });
 
   it('detects file paths with Windows style drive prefix', () => {
-    const result = linkPaths('foo() C:/b/c.js:44:55');
-    expect(result).toContain('data-path="C:/b/c.js"');
+    const result = linkPaths('foo() C:\\b\\c.js:44:55');
+    expect(result).toContain('data-path="C:\\b\\c.js"');
   });
 
   it('allow ommitting the column number', () => {
@@ -24,10 +24,24 @@ describe('linkPaths', () => {
     expect(result).toContain('data-column=""');
   });
 
+  it('allow ommitting the column and line numbers', () => {
+    const result = linkPaths('foo() b/c.js');
+    expect(result).toContain('data-path="b/c.js"');
+    expect(result).toContain('data-line=""');
+    expect(result).toContain('data-column=""');
+  });
+
   it('links multiple paths', () => {
     const multilineResult = linkPaths('foo() b/c.js:44:5\nbar() b/c.js:45:56',
     );
     expect(multilineResult).toContain('foo() <a');
     expect(multilineResult).toContain('bar() <a');
+  });
+
+  it('detects python file paths with line numbers', () => {
+    const result = linkPaths('File "b/c.py", line 4, in <module>');
+    expect(result).toContain('data-path="b/c.py"');
+    expect(result).toContain('data-line="4"');
+    expect(result).toContain('data-column=""');
   });
 });


### PR DESCRIPTION
Fix error stack links detecting for Windows paths. Add python error trace support. Add common files linking option.