### PR TITLE
Fix and improve quote support in Run Options

### DIFF
--- a/lib/script-options-view.js
+++ b/lib/script-options-view.js
@@ -87,8 +87,8 @@ export default class ScriptOptionsView extends View {
     this.panel.hide();
   }
 
-  splitArgs(element) {
-    let args = element.get(0).getModel().getText().trim();
+  static splitArgs(argText) {
+    let args = argText.trim();
 
     if (args.indexOf('"') === -1 && args.indexOf("'") === -1) {
       // no escaping, just split
@@ -133,9 +133,13 @@ export default class ScriptOptionsView extends View {
     return {
       workingDirectory: this.inputCwd.get(0).getModel().getText(),
       cmd: this.inputCommand.get(0).getModel().getText(),
-      cmdArgs: this.splitArgs(this.inputCommandArgs),
+      cmdArgs: this.constructor.splitArgs(
+        this.inputCommandArgs.get(0).getModel().getText(),
+      ),
       env: this.inputEnv.get(0).getModel().getText(),
-      scriptArgs: this.splitArgs(this.inputScriptArgs),
+      scriptArgs: this.constructor.splitArgs(
+        this.inputScriptArgs.get(0).getModel().getText(),
+      ),
     };
   }
 

--- a/lib/script-options-view.js
+++ b/lib/script-options-view.js
@@ -97,13 +97,8 @@ export default class ScriptOptionsView extends View {
 
     const replaces = {};
 
-    const regexps = [/"[^"]*"/ig, /'[^']*'/ig];
-
-    let matches;
     // find strings in arguments
-    regexps.forEach((regex) => {
-      matches = (matches || []).concat((args.match(regex)) || []);
-    });
+    const matches = args.match(/(["']).*?\1/g) || [];
 
     // format replacement as bash comment to avoid replacing valid input
     matches.forEach((match) => {
@@ -113,7 +108,7 @@ export default class ScriptOptionsView extends View {
     // replace strings
     for (const match in replaces) {
       const part = replaces[match];
-      args = args.replace(new RegExp(part, 'g'), match);
+      args = args.replace(part, match);
     }
     const split = (args.split(' ').filter(item => item !== '').map(item => item));
 
@@ -126,7 +121,7 @@ export default class ScriptOptionsView extends View {
     };
 
     // restore strings, strip quotes
-    return split.map(argument => replacer(argument).replace(/"|'/g, ''));
+    return split.map(argument => replacer(argument).replace(/^(["'])(.*)\1$/g, '$2'));
   }
 
   getOptions() {

--- a/lib/script-options-view.js
+++ b/lib/script-options-view.js
@@ -88,40 +88,25 @@ export default class ScriptOptionsView extends View {
   }
 
   static splitArgs(argText) {
-    let args = argText.trim();
-
-    if (args.indexOf('"') === -1 && args.indexOf("'") === -1) {
-      // no escaping, just split
-      return (args.split(' ').filter(item => item !== '').map(item => item));
-    }
-
-    const replaces = {};
-
-    // find strings in arguments
-    const matches = args.match(/(["']).*?\1/g) || [];
-
-    // format replacement as bash comment to avoid replacing valid input
-    matches.forEach((match) => {
-      replaces[`\`#match${Object.keys(replaces).length + 1}\``] = match;
-    });
-
-    // replace strings
-    for (const match in replaces) {
-      const part = replaces[match];
-      args = args.replace(part, match);
-    }
-    const split = (args.split(' ').filter(item => item !== '').map(item => item));
-
-    const replacer = (argument) => {
-      for (const match in replaces) {
-        const replacement = replaces[match];
-        argument = argument.replace(match, replacement);
+    const text = argText.trim();
+    const argSubstringRegex = /([^'"\s]+)|((["'])(.*?)\3)/g;
+    const args = [];
+    let lastMatchEndPosition = -1;
+    let match = argSubstringRegex.exec(text);
+    while (match !== null) {
+      const matchWithoutQuotes = match[1] || match[4];
+      // Combine current result with last match, if last match ended where this
+      // one begins.
+      if (lastMatchEndPosition === match.index) {
+        args[args.length - 1] += matchWithoutQuotes;
+      } else {
+        args.push(matchWithoutQuotes);
       }
-      return argument;
-    };
 
-    // restore strings, strip quotes
-    return split.map(argument => replacer(argument).replace(/^(["'])(.*)\1$/g, '$2'));
+      lastMatchEndPosition = argSubstringRegex.lastIndex;
+      match = argSubstringRegex.exec(text);
+    }
+    return args;
   }
 
   getOptions() {

--- a/lib/script-options-view.js
+++ b/lib/script-options-view.js
@@ -102,7 +102,7 @@ export default class ScriptOptionsView extends View {
     let matches;
     // find strings in arguments
     regexps.forEach((regex) => {
-      matches = (!matches ? matches : []).concat((args.match(regex)) || []);
+      matches = (matches || []).concat((args.match(regex)) || []);
     });
 
     // format replacement as bash comment to avoid replacing valid input

--- a/spec/script-options-view-spec.js
+++ b/spec/script-options-view-spec.js
@@ -1,0 +1,59 @@
+'use babel';
+
+/* eslint-disable no-underscore-dangle */
+import ScriptOptionsView from '../lib/script-options-view';
+
+describe('ScriptOptionsView', () => {
+  describe('splitArgs', () => {
+    [{
+      text: '',
+      expectedArgs: [],
+      description: 'returns an empty array for empty string',
+    }, {
+      text: ' \t\n',
+      expectedArgs: [],
+      description: 'returns an empty array for just whitespace',
+    }, {
+      text: 'arg1 arg2',
+      expectedArgs: ['arg1', 'arg2'],
+      description: 'splits arguments on whitespace',
+    }, {
+      text: 'arg1=val1 arg2',
+      expectedArgs: ['arg1=val1', 'arg2'],
+      description: 'keeps argument values',
+    }, {
+      text: '"foo bar" arg2',
+      expectedArgs: ['foo bar', 'arg2'],
+      description: 'does not split quoted arguments on whitespace',
+    }, {
+      text: '\'foo bar\' arg2',
+      expectedArgs: ['foo bar', 'arg2'],
+      description: 'recognizes single quotes',
+    }, {
+      text: '"foo bar" "another string"',
+      expectedArgs: ['foo bar', 'another string'],
+      description: 'handles multiple quoted arguments',
+    }, {
+      text: '\'foo bar\' \'another string\'',
+      expectedArgs: ['foo bar', 'another string'],
+      description: 'handles multiple single quoted arguments',
+    }, {
+      text: '"foo bar" \'another string\'',
+      expectedArgs: ['foo bar', 'another string'],
+      description: 'handles multiple quoted arguments, with mixed single and double quotes',
+    }, {
+      text: 'arg1="foo bar"',
+      expectedArgs: ['arg1=foo bar'],
+      description: 'strips quotes from argument values',
+    }, {
+      text: 'arg1=\'foo bar\'',
+      expectedArgs: ['arg1=foo bar'],
+      description: 'strips single quotes from argument values',
+    }].forEach(({ text, expectedArgs, description }) => {
+      it(description, () => {
+        const args = ScriptOptionsView.splitArgs(text);
+        expect(args).toEqual(expectedArgs);
+      });
+    });
+  });
+});

--- a/spec/script-options-view-spec.js
+++ b/spec/script-options-view-spec.js
@@ -43,12 +43,16 @@ describe('ScriptOptionsView', () => {
       description: 'handles multiple quoted arguments, with mixed single and double quotes',
     }, {
       text: 'arg1="foo bar"',
-      expectedArgs: ['arg1=foo bar'],
-      description: 'strips quotes from argument values',
+      expectedArgs: ['arg1="foo bar"'],
+      description: 'does not strip quotes from argument values',
     }, {
       text: 'arg1=\'foo bar\'',
-      expectedArgs: ['arg1=foo bar'],
-      description: 'strips single quotes from argument values',
+      expectedArgs: ['arg1=\'foo bar\''],
+      description: 'does not strip single quotes from argument values',
+    }, {
+      text: '-e \'(load "{FILE_ACTIVE}")\'',
+      expectedArgs: ['-e', '(load "{FILE_ACTIVE}")'],
+      description: 'keeps nested quotes intact',
     }].forEach(({ text, expectedArgs, description }) => {
       it(description, () => {
         const args = ScriptOptionsView.splitArgs(text);

--- a/spec/script-options-view-spec.js
+++ b/spec/script-options-view-spec.js
@@ -43,16 +43,20 @@ describe('ScriptOptionsView', () => {
       description: 'handles multiple quoted arguments, with mixed single and double quotes',
     }, {
       text: 'arg1="foo bar"',
-      expectedArgs: ['arg1="foo bar"'],
-      description: 'does not strip quotes from argument values',
+      expectedArgs: ['arg1=foo bar'],
+      description: 'strips quotes from argument values',
     }, {
       text: 'arg1=\'foo bar\'',
-      expectedArgs: ['arg1=\'foo bar\''],
-      description: 'does not strip single quotes from argument values',
+      expectedArgs: ['arg1=foo bar'],
+      description: 'strips single quotes from argument values',
     }, {
       text: '-e \'(load "{FILE_ACTIVE}")\'',
       expectedArgs: ['-e', '(load "{FILE_ACTIVE}")'],
       description: 'keeps nested quotes intact',
+    }, {
+      text: 'we"ird way to inc"l"ude spaces in arg"s',
+      expectedArgs: ['weird way to include spaces in args'],
+      description: 'supports multiple top level quotes',
     }].forEach(({ text, expectedArgs, description }) => {
       it(description, () => {
         const args = ScriptOptionsView.splitArgs(text);


### PR DESCRIPTION
Did these fixes and changes to be able to use `-e '(load "{FILE_ACTIVE}")'` as Command Arguments with `racket`. Additional info in commits.