### PR TITLE
Improve support for modern JavaScript

### DIFF
--- a/examples/modern.js
+++ b/examples/modern.js
@@ -1,0 +1,11 @@
+import {exec} from 'child_process'
+
+const timeout = s => new Promise(resolve => setTimeout(resolve, s * 1000)) // ms
+
+const sleep = async(s, message) => {
+  console.log("Awaiting Promise…") // This selected line should run.
+  await timeout(s)
+  return console.log(message)
+}
+
+sleep(1, "Done.")

--- a/lib/grammars.coffee
+++ b/lib/grammars.coffee
@@ -431,18 +431,18 @@ module.exports =
 
   JavaScript:
     "Selection Based":
-      command: "node"
+      command: "babel-node"
       args: (context)  -> ['-e', context.getCode()]
     "File Based":
-      command: "node"
+      command: "babel-node"
       args: (context) -> [context.filepath]
 
   'JavaScript with JSX':
     "Selection Based":
-      command: "node"
+      command: "babel-node"
       args: (context)  -> ['-e', context.getCode()]
     "File Based":
-      command: "node"
+      command: "babel-node"
       args: (context) -> [context.filepath]
 
   "JavaScript for Automation (JXA)":

--- a/package.json
+++ b/package.json
@@ -340,6 +340,7 @@
     "uuid": "^3.0.1"
   },
   "optionalDependencies": {
+    "babel-cli": "^6.26.0",
     "coffeescript": "^2"
   },
   "devDependencies": {


### PR DESCRIPTION
Also utilises _babel-preset-env_ to automatically target the current version of Node being run by Atom.