### PR TITLE
Fixes #1499

### DIFF
--- a/lib/grammars/java.coffee
+++ b/lib/grammars/java.coffee
@@ -36,4 +36,4 @@ module.exports =
   Processing:
     'File Based':
       command: 'processing-java'
-      args: ({filepath}) -> ["--sketch='#{path.dirname(filepath)}'", '--run']
+      args: ({filepath}) -> ["--sketch=#{path.dirname(filepath)}", "--run"]


### PR DESCRIPTION
Running processing-java works again.
Open ~/.atom/packages/script/examples/bounce/bounce.pde and hit cmd+i / ctrl+i.
  