### PR TITLE
Enable right-side script output

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
   },
   "dependencies": {
     "ansi-to-html": "^0.4.2",
-    "atom-message-panel": "1.2.7",
+    "atom-message-panel": "1.3.0",
     "atom-space-pen-views": "^2.0.3",
     "babel-preset-env": "^1.6.0",
     "strip-ansi": "^3.0.0",


### PR DESCRIPTION
- Issue: The script output window can not be opened on the right side, which might not be friendly for wide-screen displays.
- Solution: upgraded dependency "atom-message-panel" version to "1.3.0" to enable opening script output panel on the right. To enable right-side-script-view, a further step is needed:
modify `lib/script-view.js`, add `position: right` in the constructor's `super` method.
A settings configuration item is better but I do not have time to implement it.

Note: I think this PR will not be accepted since the authors deliberately pin the atom-message-panel version to 1.2.7 to fix the issue #1223.