### PR TITLE
 Overdrive the default args with the customed ones 

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -155,13 +155,13 @@ export default class Runner {
     // cmdArgs = customed command args from:
     // - a user's profil
     // - the 'Configure Run Options' panel
-    let cmdArgs = this.scriptOptions.cmdArgs;
+    const cmdArgs = this.scriptOptions.cmdArgs;
 
     // Let's overdrive the default args with the customed ones
     let args = (cmdArgs.length) ? cmdArgs : extraArgs;
 
     // Do not forget to concat the script args after the command args
-    let scriptArgs = this.scriptOptions.scriptArgs;
+    const scriptArgs = this.scriptOptions.scriptArgs;
     args = args.concat(scriptArgs);
 
     const projectPath = this.getProjectPath || '';


### PR DESCRIPTION
This update will solve all the python -u issues.
For example, you can run python -m unittest now without the -u arg and the filepath.