### PR TITLE
fix atom-message-panel bug (error on message-panel/window close)

### DIFF
--- a/lib/script-view.js
+++ b/lib/script-view.js
@@ -74,8 +74,7 @@ export default class ScriptView extends MessagePanelView {
   resetView(title = 'Loading...') {
     // Display window and load message
 
-    // First run, create view
-    if (!this.hasParent()) { this.attach(); }
+    this.attach();
 
     this.setHeaderTitle(title);
     this.setHeaderStatus('start');

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,9 +138,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "atom-message-panel": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/atom-message-panel/-/atom-message-panel-1.3.0.tgz",
-      "integrity": "sha1-BOICKVQHZrzTVlVdq/qY1b7dMTw=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/atom-message-panel/-/atom-message-panel-1.3.1.tgz",
+      "integrity": "sha512-nLi19faNBl/kabrf6itBkHcLrnpUeiGbpda+dHufAODKH+I+odoPRCxx7EZ+mCHEsBMhHNXxLWOLA+Mm9pumbA==",
       "requires": {
         "atom-space-pen-views": "^2.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
   },
   "dependencies": {
     "ansi-to-html": "^0.4.2",
-    "atom-message-panel": "1.3.0",
+    "atom-message-panel": "1.3.1",
     "atom-space-pen-views": "^2.0.3",
     "babel-preset-env": "^1.6.0",
     "strip-ansi": "^3.0.0",


### PR DESCRIPTION
This should fix #1995, #1997 and #2002.

The [atom-message-panel](https://github.com/tcarlsen/atom-message-panel) package was recently updated to include a fix on their side, but with just the version bump, the script window appears only once and never again after it's closed (as reported in several issues on their side as well, see [tcarlsen/atom-message-panel/#91](https://github.com/tcarlsen/atom-message-panel/issues/91) and [tcarlsen/atom-message-panel/#90](https://github.com/tcarlsen/atom-message-panel/pull/90)).

Feel free to test this on your machines!