### PR TITLE
Update java.js

### DIFF
--- a/lib/grammars/java.js
+++ b/lib/grammars/java.js
@@ -33,7 +33,7 @@ export const Java = {
 
 function KotlinArgs(filepath, jar) {
   const jarNew = (jar !== null ? jar : path.basename(filepath)).replace(/\.kt$/, ".jar")
-  const cmd = `kotlinc '${filepath}' -include-runtime -d ${jarNew} && java -jar ${jarNew}`
+  const cmd = `kotlinc '${filepath}' -include-runtime -o ${jarNew} && java -jar ${jarNew}`
   return GrammarUtils.formatArgs(cmd)
 }
 


### PR DESCRIPTION
changed -d to -o that worked for me in the cmd before by itself and is the new way from 
https://kotlinlang.org/docs/native-command-line-compiler.html#compile-the-code-from-the-console