### PR TITLE
Remove paragraph to Change Default Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,6 @@ Make sure to run `atom` from the command line to get full access to your environ
 
 Also, in this dialog you can save options as a profile for future use. For example, you can add two profiles, one for `python2.7` and another for `python3` and run scripts with a specified profile, which will be more convinient than entering options every time you want to switch python versions.
 
-**Change Default Language** by opening Atom Settings as follows: `Atom→Preferences→Open Config Folder`. Then, you can use the tree-view to navigate to and open `packages→script→lib→grammar→python.js` to make your edits. It is also possible to directly edit the code under `.atom/packages/script/lib/grammars/python.js`
-
 **Script: Run With Profile** allows you to run scripts with saved profiles. Profiles can be added in **Script: Run Options** dialog.
 
 **Script: Kill Process** will kill the process but leaves the pane open.


### PR DESCRIPTION
As we all know, this is bad practice and shouldn't be encouraged. As an alternatively, one could add a bold exclaimer that warns about the consequences, but personally I'd remove this paragraph entirely.