### PR TITLE
Support .NET Core

### DIFF
--- a/lib/grammars/c.js
+++ b/lib/grammars/c.js
@@ -55,7 +55,7 @@ const Cs = {
       if (windows) {
         return [`/c csc /out:${exe} ${tmpFile} && ${exe}`]
       } else {
-        return ["-c", `csc /out:${exe} ${tmpFile} && mono ${exe}`]
+        return ["-c", `csc /out:${exe} ${tmpFile} && dotnet ${exe}`]
       }
     },
   },
@@ -66,24 +66,24 @@ const Cs = {
       if (windows) {
         return [`/c csc ${filepath} && ${exe}`]
       } else {
-        return ["-c", `csc '${filepath}' && mono ${exe}`]
+        return ["-c", `csc '${filepath}' && dotnet ${exe}`]
       }
     },
   },
 }
 const CSScriptFile = {
   "Selection Based": {
-    command: "scriptcs",
+    command: "dotnet",
     args(context) {
       const code = context.getCode()
       const tmpFile = GrammarUtils.createTempFileWithCode(code, ".csx")
-      return ["-script", tmpFile]
+      return ["script", tmpFile]
     },
   },
   "File Based": {
-    command: "scriptcs",
+    command: "dotnet",
     args({ filepath }) {
-      return ["-script", filepath]
+      return ["script", filepath]
     },
   },
 }

--- a/lib/grammars/index.js
+++ b/lib/grammars/index.js
@@ -118,9 +118,9 @@ const OtherGrammars = {
 
   "F#": {
     "File Based": {
-      command: windows ? "fsi" : "fsharpi",
+      command: windows ? "fsi" : "dotnet",
       args({ filepath }) {
-        return ["--exec", filepath]
+        return windows ? ["--exec", filepath] : ["fsi", "--exec", filepath]
       },
     },
   },


### PR DESCRIPTION
### Requirements for Adding, Changing, or Removing a Feature

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Issue or RFC Endorsed by Atom's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The change use different commands for Linux.
Mainly, depending on **.NET Core**.

For C#, `dotnet` is used instead of `mono`.
> Might want to change `csc` to `dotnet csc` when that becomes available.

For C# scripts, `dotnet script` is used instead of `scriptcs`.
> Might want to change to `dotnet csi` when that beomes available.

For F# scripts, `dotnet fsi` is used instead of `fsharpi`

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I haven't made checks which may need the **lookpath** Node.js package.
That is to check maybe if `mono` or `dotnet` is installed.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

The `dotnet script` seems to be only in user directory.
That may mean `.csx` won't work outside the user environment.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

I use certain files to test this.

- **C# example**
```
using System;

namespace HelloWorld
{
  class Program
  {
    static void Main(string[] args)
    {
      Console.WriteLine("Hello World!");
    }
  }
}
```

- **C# script**
```
//usr/bin/env dotnet script "$0" "$@";exit $?

var fw = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
var arch = System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture;
Console.WriteLine($"Hello world ({fw}, {arch})");
```

- **F# script**
```
//usr/bin/env dotnet fsi "$0" "$@";exit $?

printfn "Hello world!"
```

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->
